### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/110/895/256/5/1108952565.geojson
+++ b/data/110/895/256/5/1108952565.geojson
@@ -290,6 +290,9 @@
     "wof:concordances":{},
     "wof:country":"FM",
     "wof:created":1459009389,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ae0e9924998f53d55f748f3345ffabf",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         }
     ],
     "wof:id":1108952565,
-    "wof:lastmodified":1566596158,
+    "wof:lastmodified":1582315528,
     "wof:name":"Palikir",
     "wof:parent_id":85671217,
     "wof:placetype":"locality",

--- a/data/856/324/31/85632431.geojson
+++ b/data/856/324/31/85632431.geojson
@@ -964,6 +964,10 @@
     },
     "wof:country":"FM",
     "wof:country_alpha3":"FSM",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"86097d6a34225faedd269b8159f95714",
     "wof:hierarchy":[
         {
@@ -978,7 +982,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566596141,
+    "wof:lastmodified":1582315527,
     "wof:name":"Federated States of Micronesia",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/890/413/003/890413003.geojson
+++ b/data/890/413/003/890413003.geojson
@@ -42,6 +42,9 @@
     },
     "wof:country":"FM",
     "wof:created":1469050984,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3077deadbd4550828e729d85177b462",
     "wof:hierarchy":[
         {
@@ -52,7 +55,7 @@
         }
     ],
     "wof:id":890413003,
-    "wof:lastmodified":1566596168,
+    "wof:lastmodified":1582315528,
     "wof:name":"Nema Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/009/890413009.geojson
+++ b/data/890/413/009/890413009.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"FM",
     "wof:created":1469050985,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"293a61e127b6f8aa14f607fae29808e2",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890413009,
-    "wof:lastmodified":1566596168,
+    "wof:lastmodified":1582315528,
     "wof:name":"Murilo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.