### PR TITLE
Name updates

### DIFF
--- a/data/890/412/979/890412979.geojson
+++ b/data/890/412/979/890412979.geojson
@@ -95,7 +95,7 @@
         "\u0c95\u0cca\u0cb8\u0ccd\u0cb0\u0cc7"
     ],
     "name:kat_x_preferred":[
-        "\u10d9\u10dd\u10e1\u10e0\u10d0\u10d4 "
+        "\u10d9\u10dd\u10e1\u10e0\u10d0\u10d4"
     ],
     "name:kor_x_preferred":[
         "\ucf54\uc2a4\ub77c\uc5d0\uc8fc"
@@ -205,7 +205,7 @@
         }
     ],
     "wof:id":890412979,
-    "wof:lastmodified":1566596170,
+    "wof:lastmodified":1587163142,
     "wof:name":"Kosrae",
     "wof:parent_id":85671231,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.