### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/114/190/914/1/1141909141.geojson
+++ b/data/114/190/914/1/1141909141.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"158.149974324,6.91664369601,158.149974324,6.91664369601",
+    "geom:bbox":"158.149974,6.916644,158.149974,6.916644",
     "geom:latitude":6.916644,
     "geom:longitude":158.149974,
     "iso:country":"FM",
@@ -27,14 +27,29 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0644\u064a\u0643\u064a\u0631"
     ],
+    "name:ary_x_preferred":[
+        "\u067e\u0627\u0644\u064a\u0643\u064a\u0631"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0644\u064a\u0643\u064a\u0631"
+    ],
     "name:ast_x_preferred":[
+        "Palikir"
+    ],
+    "name:avk_x_preferred":[
         "Palikir"
     ],
     "name:aze_x_preferred":[
         "Palikir"
     ],
+    "name:ban_x_preferred":[
+        "Palikir"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u043b\u0456\u043a\u0456\u0440"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u043b\u0456\u043a\u0456\u0440"
     ],
     "name:ben_x_preferred":[
         "\u09aa\u09be\u09b2\u09bf\u0995\u09bf\u09b0"
@@ -99,6 +114,9 @@
     "name:gla_x_preferred":[
         "Palikir"
     ],
+    "name:gle_x_preferred":[
+        "Palikir"
+    ],
     "name:glg_x_preferred":[
         "Palikir"
     ],
@@ -116,6 +134,9 @@
     ],
     "name:hin_x_preferred":[
         "\u092a\u093e\u0932\u093f\u0915\u093f\u0930"
+    ],
+    "name:hin_x_variant":[
+        "\u092a\u0947\u0932\u093f\u0915\u093f\u092f\u0930"
     ],
     "name:hrv_x_preferred":[
         "Palikir"
@@ -165,6 +186,9 @@
     "name:lav_x_preferred":[
         "Palikira"
     ],
+    "name:lij_x_preferred":[
+        "Palikir"
+    ],
     "name:lit_x_preferred":[
         "Palikyras"
     ],
@@ -173,6 +197,9 @@
     ],
     "name:ltz_x_preferred":[
         "Palikir"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d2a\u0d3e\u0d32\u0d3f\u0d15\u0d3f\u0d7c"
     ],
     "name:mar_x_preferred":[
         "\u092a\u093e\u0932\u093f\u0915\u093f\u0930"
@@ -213,6 +240,12 @@
     "name:por_x_preferred":[
         "Palikir"
     ],
+    "name:por_x_variant":[
+        "Paliquir"
+    ],
+    "name:pus_x_preferred":[
+        "\u067e\u0627\u0644\u06cc\u06a9\u06cc\u0631"
+    ],
     "name:ron_x_preferred":[
         "Palikir"
     ],
@@ -237,6 +270,9 @@
     "name:spa_x_preferred":[
         "Palikir"
     ],
+    "name:srd_x_preferred":[
+        "Palikir"
+    ],
     "name:srp_x_preferred":[
         "\u041f\u0430\u043b\u0438\u043a\u0438\u0440"
     ],
@@ -254,6 +290,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c2a\u0c3e\u0c32\u0c40\u0c15\u0c40\u0c30\u0c4d"
+    ],
+    "name:tgk_x_preferred":[
+        "\u041f\u0430\u043b\u0438\u043a\u0438\u0440"
     ],
     "name:tgl_x_preferred":[
         "Palikir"
@@ -281,6 +320,9 @@
     ],
     "name:wuu_x_preferred":[
         "\u5e15\u5229\u57fa\u723e"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10de\u10d0\u10da\u10d8\u10d9\u10d8\u10e0\u10d8"
     ],
     "name:yue_x_preferred":[
         "\u5e15\u5229\u57fa\u723e"
@@ -395,7 +437,7 @@
     },
     "wof:country":"FM",
     "wof:created":1499131031,
-    "wof:geomhash":"4f423b60fb735c4a521931e225efa882",
+    "wof:geomhash":"ee29d6ec679fa9cb73358e84a3b91d05",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -405,7 +447,7 @@
         }
     ],
     "wof:id":1141909141,
-    "wof:lastmodified":1566596195,
+    "wof:lastmodified":1690893345,
     "wof:name":"Palikir",
     "wof:parent_id":85671217,
     "wof:placetype":"locality",
@@ -415,10 +457,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    158.1499743237623,
-    6.91664369600772,
-    158.1499743237623,
-    6.91664369600772
+    158.149974,
+    6.916644,
+    158.149974,
+    6.916644
 ],
-  "geometry": {"coordinates":[158.14997432376231,6.91664369600772],"type":"Point"}
+  "geometry": {"coordinates":[158.14997399999999,6.916644],"type":"Point"}
 }

--- a/data/421/195/035/421195035.geojson
+++ b/data/421/195/035/421195035.geojson
@@ -41,6 +41,9 @@
     "name:pol_x_preferred":[
         "Maap"
     ],
+    "name:por_x_preferred":[
+        "Maap"
+    ],
     "name:spa_x_preferred":[
         "Maap"
     ],
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":421195035,
-    "wof:lastmodified":1566596166,
+    "wof:lastmodified":1690893330,
     "wof:name":"Maap",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/195/827/421195827.geojson
+++ b/data/421/195/827/421195827.geojson
@@ -17,8 +17,17 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ary_x_preferred":[
+        "\u0648\u064a\u0646\u0648"
+    ],
+    "name:cat_x_preferred":[
+        "Weno"
+    ],
     "name:ceb_x_preferred":[
         "Weno Town"
+    ],
+    "name:ces_x_preferred":[
+        "Weno"
     ],
     "name:deu_x_preferred":[
         "Weno"
@@ -41,6 +50,9 @@
     "name:heb_x_variant":[
         "\u05d5\u05e0\u05d5"
     ],
+    "name:ind_x_preferred":[
+        "Weno"
+    ],
     "name:ita_x_preferred":[
         "Weno"
     ],
@@ -49,6 +61,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc6e8\ub178"
+    ],
+    "name:lav_x_preferred":[
+        "Veno"
     ],
     "name:lit_x_preferred":[
         "Venas"
@@ -74,6 +89,9 @@
     "name:rus_x_preferred":[
         "\u0412\u0435\u043d\u043e"
     ],
+    "name:slk_x_preferred":[
+        "Weno"
+    ],
     "name:spa_x_preferred":[
         "Weno"
     ],
@@ -85,6 +103,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e27\u0e42\u0e19"
+    ],
+    "name:tur_x_preferred":[
+        "Weno"
     ],
     "name:ukr_x_preferred":[
         "\u0412\u0435\u043d\u043e"
@@ -134,7 +155,7 @@
         }
     ],
     "wof:id":421195827,
-    "wof:lastmodified":1566596166,
+    "wof:lastmodified":1690893330,
     "wof:name":"Weno",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/324/31/85632431.geojson
+++ b/data/856/324/31/85632431.geojson
@@ -40,6 +40,9 @@
     "name:aka_x_preferred":[
         "Maekronehyia"
     ],
+    "name:aka_x_variant":[
+        "Federated States of Micronesia"
+    ],
     "name:als_x_preferred":[
         "F\u00f6derierte Staaten von Mikronesien"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:amh_x_variant":[
         "\u121a\u12ad\u122e\u1294\u12e2\u12eb"
+    ],
+    "name:ami_x_preferred":[
+        "Federated States of Micronesia"
     ],
     "name:ara_x_preferred":[
         "\u0648\u0644\u0627\u064a\u0627\u062a \u0645\u064a\u0643\u0631\u0648\u0646\u064a\u0633\u064a\u0627 \u0627\u0644\u0645\u062a\u062d\u062f\u0629"
@@ -64,6 +70,9 @@
     "name:ast_x_preferred":[
         "Estaos Federaos de Micronesia"
     ],
+    "name:avk_x_preferred":[
+        "Mikronesia Galda"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u06cc\u06a9\u0631\u0648\u0646\u0626\u0632\u06cc\u0627 \u0641\u062f\u0631\u0627\u062a\u06cc\u0648 \u0627\u06cc\u0627\u0644\u062a\u0644\u0631\u06cc"
     ],
@@ -78,6 +87,9 @@
     ],
     "name:bam_x_preferred":[
         "Mikironesi"
+    ],
+    "name:ban_x_preferred":[
+        "Negara F\u00e9derasi Mikron\u00e9sia"
     ],
     "name:bcl_x_preferred":[
         "Maykronisya"
@@ -275,6 +287,9 @@
         "Micron\u00e8sie (payis)",
         "Micron\u00e8sie"
     ],
+    "name:frr_x_preferred":[
+        "Tupsl\u00f6\u00f6den Stooten faan Mikroneesien"
+    ],
     "name:fry_x_preferred":[
         "Mikroneezje (l\u00e2n)",
         "Mikroneezje"
@@ -333,6 +348,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05de\u05d9\u05e7\u05e8\u05d5\u05e0\u05d6\u05d9\u05d4"
+    ],
+    "name:heb_x_variant":[
+        "\u05d4\u05de\u05d3\u05d9\u05e0\u05d5\u05ea \u05d4\u05e4\u05d3\u05e8\u05d8\u05d9\u05d1\u05d9\u05d5\u05ea \u05e9\u05dc \u05de\u05d9\u05e7\u05e8\u05d5\u05e0\u05d6\u05d9\u05d4"
     ],
     "name:hif_x_preferred":[
         "Federated States of Micronesia"
@@ -512,6 +530,9 @@
     "name:mon_x_preferred":[
         "\u041c\u0438\u043a\u0440\u043e\u043d\u0435\u0437\u0438\u0439\u043d \u0425\u043e\u043b\u0431\u043e\u043e\u043d\u044b \u0423\u043b\u0441"
     ],
+    "name:mri_x_preferred":[
+        "Wehenga Whakaminenga o Maikoron\u012bhia"
+    ],
     "name:msa_x_preferred":[
         "Persekutuan Mikronesia"
     ],
@@ -613,6 +634,9 @@
         "Micron\u00e9sia",
         "Micron\u00e9sia, Estados Federados da"
     ],
+    "name:pus_x_preferred":[
+        "\u062f \u0645\u06cc\u06a9\u0631\u0648\u0646\u0632\u064a \u0641\u062f\u0631\u0627\u0644 \u067c\u0627\u067e\u0648\u06ab\u0627\u0646"
+    ],
     "name:que_x_preferred":[
         "Mikrunisya (mama llaqta)",
         "Mikrunisya"
@@ -654,6 +678,9 @@
     "name:sgs_x_preferred":[
         "Mikronez\u0117j\u0117"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1081\u1030\u1019\u103a\u1088\u1010\u102f\u1019\u103a \u1019\u1062\u1086\u1087\u1076\u101b\u1030\u101d\u103a\u1087\u107c\u1031\u1038\u101e\u103b\u1083\u1038"
+    ],
     "name:sin_x_preferred":[
         "\u0db8\u0dba\u0dd2\u0d9a\u0dca\u200d\u0dbb\u0ddc\u0db1\u0dd3\u0dc3\u0dd2\u0dba\u0dcf \u0d92\u0d9a\u0dcf\u0db6\u0daf\u0dca\u0db0 \u0da2\u0db1\u0db4\u0daf\u0dba"
     ],
@@ -678,6 +705,9 @@
     ],
     "name:sna_x_variant":[
         "Micronesia"
+    ],
+    "name:snd_x_preferred":[
+        "\u0645\u0627\u0626\u06aa\u0631\u0648\u0646\u064a\u0634\u064a\u0627 \u062c\u0648\u0646 \u0641\u064a\u068a\u0631\u064a\u067d\u064a\u068a \u0627\u0633\u067d\u064a\u067d\u0633"
     ],
     "name:som_x_preferred":[
         "Micronesia"
@@ -1048,7 +1078,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1617827387,
+    "wof:lastmodified":1690893328,
     "wof:name":"Federated States of Micronesia",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/712/17/85671217.geojson
+++ b/data/856/712/17/85671217.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0644\u0627\u064a\u0629 \u0628\u0648\u0647\u0646\u0628\u064a"
     ],
+    "name:ary_x_preferred":[
+        "\u0648\u064a\u0644\u0627\u064a\u0629 \u067e\u0648\u0647\u0646\u067e\u064a"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09cb\u09b9\u09c7\u09a8\u09cd\u09aa\u09bf \u0985\u0999\u09cd\u0997\u09b0\u09be\u099c\u09cd\u09af"
     ],
@@ -55,6 +58,9 @@
         "Pohnpei",
         "Pohnpei State"
     ],
+    "name:eus_x_preferred":[
+        "Pohnpei"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0627\u0644\u062a \u067e\u0648\u0646\u0627\u067e\u06cc"
     ],
@@ -62,6 +68,9 @@
         "Pohnpein osavaltio"
     ],
     "name:fra_x_preferred":[
+        "Pohnpei"
+    ],
+    "name:frr_x_preferred":[
         "Pohnpei"
     ],
     "name:glg_x_preferred":[
@@ -72,6 +81,12 @@
     ],
     "name:hin_x_preferred":[
         "\u092a\u094b\u0939\u094d\u0928\u092a\u0947\u0907 \u0930\u093e\u091c\u094d\u092f"
+    ],
+    "name:hrv_x_preferred":[
+        "Pohnpei"
+    ],
+    "name:hun_x_preferred":[
+        "Pohnpei"
     ],
     "name:ind_x_preferred":[
         "Negara bagian Pohnpei"
@@ -91,6 +106,9 @@
     "name:kor_x_preferred":[
         "\ud3f0\ud398\uc774 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ud3f0\ud398\uc774\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Ponpejas \u0161tats"
     ],
@@ -102,6 +120,9 @@
     ],
     "name:msa_x_preferred":[
         "Pohnpei State"
+    ],
+    "name:nan_x_preferred":[
+        "Pohnpei Chiu"
     ],
     "name:nld_x_preferred":[
         "Pohnpei"
@@ -271,7 +292,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494975,
+    "wof:lastmodified":1690893329,
     "wof:name":"Pohnpei",
     "wof:parent_id":85632431,
     "wof:placetype":"region",

--- a/data/856/712/21/85671221.geojson
+++ b/data/856/712/21/85671221.geojson
@@ -33,6 +33,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0644\u0627\u064a\u0629 \u062a\u0634\u0648\u0643"
     ],
+    "name:ary_x_preferred":[
+        "\u0648\u064a\u0644\u0627\u064a\u0629 \u062a\u0634\u0648\u0648\u0643"
+    ],
     "name:bel_x_preferred":[
         "\u0410\u0441\u0442\u0440\u0430\u0432\u044b \u0427\u0443\u045e\u043a"
     ],
@@ -70,6 +73,9 @@
     "name:est_x_preferred":[
         "Chuuki saared"
     ],
+    "name:eus_x_preferred":[
+        "Chuuk"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0627\u0644\u062a \u0686\u0648\u06a9"
     ],
@@ -77,6 +83,9 @@
         "Chuuk"
     ],
     "name:fra_x_preferred":[
+        "Chuuk"
+    ],
+    "name:frr_x_preferred":[
         "Chuuk"
     ],
     "name:glg_x_preferred":[
@@ -90,6 +99,9 @@
     ],
     "name:hin_x_preferred":[
         "\u091a\u0942\u0915 \u0930\u093e\u091c\u094d\u092f"
+    ],
+    "name:hrv_x_preferred":[
+        "Chuuk"
     ],
     "name:hun_x_preferred":[
         "Chuuk"
@@ -133,6 +145,9 @@
     "name:msa_x_preferred":[
         "Chuuk State"
     ],
+    "name:nan_x_preferred":[
+        "Chuuk Chiu"
+    ],
     "name:nld_x_preferred":[
         "Chuuk"
     ],
@@ -153,6 +168,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0422\u0440\u0443\u043a"
+    ],
+    "name:rus_x_variant":[
+        "\u0427\u0443\u0443\u043a"
     ],
     "name:sin_x_preferred":[
         "\u0da0\u0d9a\u0dca \u0dbb\u0dcf\u0da2\u0dca\u200d\u0dba"
@@ -193,11 +211,20 @@
     "name:wuu_x_preferred":[
         "\u695a\u514b\u5dde"
     ],
+    "name:wuu_x_variant":[
+        "\u4e18\u514b\u5dde"
+    ],
     "name:yue_x_preferred":[
         "\u695a\u514b\u5dde"
     ],
+    "name:yue_x_variant":[
+        "\u4e18\u514b\u5dde"
+    ],
     "name:zho_x_preferred":[
         "\u695a\u514b"
+    ],
+    "name:zho_x_variant":[
+        "\u4e18\u514b\u5dde"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"FSM",
@@ -316,7 +343,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494975,
+    "wof:lastmodified":1690893329,
     "wof:name":"Chuuk",
     "wof:parent_id":85632431,
     "wof:placetype":"region",

--- a/data/856/712/27/85671227.geojson
+++ b/data/856/712/27/85671227.geojson
@@ -33,6 +33,9 @@
     "name:ara_x_preferred":[
         "\u064a\u0627\u0628"
     ],
+    "name:ary_x_preferred":[
+        "\u0648\u064a\u0644\u0627\u064a\u0629 \u064a\u0627\u067e"
+    ],
     "name:ben_x_preferred":[
         "\u0987\u09af\u09bc\u09be\u09aa"
     ],
@@ -55,6 +58,9 @@
         "Yap",
         "Yap State"
     ],
+    "name:eus_x_preferred":[
+        "Yap"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0627\u0644\u062a \u06cc\u0627\u067e"
     ],
@@ -62,6 +68,9 @@
         "Yapin osavaltio"
     ],
     "name:fra_x_preferred":[
+        "Yap"
+    ],
+    "name:frr_x_preferred":[
         "Yap"
     ],
     "name:glg_x_preferred":[
@@ -73,10 +82,16 @@
     "name:hin_x_preferred":[
         "\u092f\u093e\u092a \u0930\u093e\u091c\u094d\u092f"
     ],
+    "name:hrv_x_preferred":[
+        "Yap"
+    ],
     "name:hun_x_preferred":[
         "Yap"
     ],
     "name:ind_x_preferred":[
+        "Yap"
+    ],
+    "name:ita_x_preferred":[
         "Yap"
     ],
     "name:jpn_x_preferred":[
@@ -90,6 +105,12 @@
     ],
     "name:kor_x_variant":[
         "\uc57c\ud504\uc8fc"
+    ],
+    "name:lav_x_preferred":[
+        "Japa"
+    ],
+    "name:nan_x_preferred":[
+        "Yap Chiu"
     ],
     "name:nld_x_preferred":[
         "Yap"
@@ -245,7 +266,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494975,
+    "wof:lastmodified":1690893329,
     "wof:name":"Yap",
     "wof:parent_id":85632431,
     "wof:placetype":"region",

--- a/data/856/712/31/85671231.geojson
+++ b/data/856/712/31/85671231.geojson
@@ -30,6 +30,9 @@
     "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
+    "name:ary_x_preferred":[
+        "\u0648\u064a\u0644\u0627\u064a\u0629 \u0643\u0648\u0635\u0631\u064a"
+    ],
     "name:deu_x_preferred":[
         "Bundesstaat Kosrae"
     ],
@@ -39,10 +42,16 @@
     "name:eng_x_variant":[
         "Kosrae State"
     ],
+    "name:eus_x_preferred":[
+        "Kosrae"
+    ],
     "name:fin_x_preferred":[
         "Kosraen osavaltio"
     ],
     "name:fra_x_preferred":[
+        "Kosrae"
+    ],
+    "name:frr_x_preferred":[
         "Kosrae"
     ],
     "name:heb_x_preferred":[
@@ -56,6 +65,12 @@
     ],
     "name:rus_x_preferred":[
         "\u041a\u0443\u0441\u0430\u0438\u0435"
+    ],
+    "name:rus_x_variant":[
+        "\u041a\u043e\u0441\u0440\u0430\u0435"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041a\u043e\u0441\u0440\u0430\u0454"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"FSM",
@@ -173,7 +188,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494975,
+    "wof:lastmodified":1690893329,
     "wof:name":"Kosrae",
     "wof:parent_id":85632431,
     "wof:placetype":"region",

--- a/data/890/412/927/890412927.geojson
+++ b/data/890/412/927/890412927.geojson
@@ -46,6 +46,9 @@
     "name:pol_x_preferred":[
         "Onoun"
     ],
+    "name:por_x_preferred":[
+        "Ulul"
+    ],
     "name:swe_x_preferred":[
         "Onoun"
     ],
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":890412927,
-    "wof:lastmodified":1566596170,
+    "wof:lastmodified":1690893332,
     "wof:name":"Onoun",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/979/890412979.geojson
+++ b/data/890/412/979/890412979.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0633\u0631\u0627\u064a"
     ],
+    "name:ary_x_preferred":[
+        "\u0648\u064a\u0644\u0627\u064a\u0629 \u0643\u0648\u0635\u0631\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0633\u0631\u0627\u0649"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u041a\u0430\u0441\u0440\u0430\u0435"
     ],
@@ -79,8 +85,14 @@
     "name:heb_x_preferred":[
         "\u05d4\u05d0\u05d9 \u05e7\u05d5\u05e1\u05e8\u05d4"
     ],
+    "name:heb_x_variant":[
+        "\u05e7\u05d5\u05e1\u05e8\u05d0\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u0915\u094b\u0936\u0930\u093e\u092f \u0930\u093e\u091c\u094d\u092f"
+    ],
+    "name:hrv_x_preferred":[
+        "Kosrae"
     ],
     "name:hun_x_preferred":[
         "Kosrae-sziget"
@@ -121,6 +133,9 @@
     "name:msa_x_preferred":[
         "Kosrae"
     ],
+    "name:nan_x_preferred":[
+        "Kosrae Chiu"
+    ],
     "name:nld_x_preferred":[
         "Kosrae"
     ],
@@ -154,6 +169,9 @@
     "name:swe_x_preferred":[
         "Kosrae"
     ],
+    "name:szl_x_preferred":[
+        "Kosrae"
+    ],
     "name:tam_x_preferred":[
         "\u0b95\u0bca\u0bb8\u0bcd\u0bb0\u0bc7"
     ],
@@ -162,6 +180,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e04\u0e2d\u0e2a\u0e44\u0e23"
+    ],
+    "name:tha_x_variant":[
+        "\u0e42\u0e01\u0e0a\u0e32\u0e40\u0e2d"
     ],
     "name:tur_x_preferred":[
         "Kosrae"
@@ -208,7 +229,7 @@
         }
     ],
     "wof:id":890412979,
-    "wof:lastmodified":1636494976,
+    "wof:lastmodified":1690893332,
     "wof:name":"Kosrae",
     "wof:parent_id":85671231,
     "wof:placetype":"locality",

--- a/data/890/412/989/890412989.geojson
+++ b/data/890/412/989/890412989.geojson
@@ -46,6 +46,12 @@
     "name:nld_x_preferred":[
         "Pisaras"
     ],
+    "name:por_x_preferred":[
+        "Pisaras"
+    ],
+    "name:spa_x_preferred":[
+        "Pisaras"
+    ],
     "name:swe_x_preferred":[
         "Pisaras"
     ],
@@ -78,7 +84,7 @@
         }
     ],
     "wof:id":890412989,
-    "wof:lastmodified":1566596170,
+    "wof:lastmodified":1690893332,
     "wof:name":"Pisaras",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/997/890412997.geojson
+++ b/data/890/412/997/890412997.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":-1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Eot Island"
+    ],
     "name:eng_x_preferred":[
         "Eot"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:spa_x_preferred":[
         "Eot"
+    ],
+    "name:swe_x_preferred":[
+        "Eot Island"
     ],
     "name:und_x_variant":[
         "Maye Jima"
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":890412997,
-    "wof:lastmodified":1566596170,
+    "wof:lastmodified":1690893332,
     "wof:name":"Eot Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/005/890413005.geojson
+++ b/data/890/413/005/890413005.geojson
@@ -40,6 +40,9 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30e2\u30cc\u30a4\u30c8\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Namonuito"
+    ],
     "name:lit_x_preferred":[
         "Namonuito atolas"
     ],
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890413005,
-    "wof:lastmodified":1566596168,
+    "wof:lastmodified":1690893331,
     "wof:name":"Namonuito Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/009/890413009.geojson
+++ b/data/890/413/009/890413009.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":-1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Murilo"
+    ],
     "name:deu_x_preferred":[
         "Murilo"
     ],
@@ -34,6 +37,9 @@
     "name:jpn_x_preferred":[
         "\u30e0\u30ea\u30ed\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Murilo"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0443\u0440\u0438\u043b\u043e"
     ],
@@ -44,6 +50,9 @@
         "Murilo"
     ],
     "name:spa_x_preferred":[
+        "Murilo"
+    ],
+    "name:swe_x_preferred":[
         "Murilo"
     ],
     "name:und_x_variant":[
@@ -87,7 +96,7 @@
         }
     ],
     "wof:id":890413009,
-    "wof:lastmodified":1582315528,
+    "wof:lastmodified":1690893331,
     "wof:name":"Murilo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/413/013/890413013.geojson
+++ b/data/890/413/013/890413013.geojson
@@ -43,6 +43,9 @@
     "name:jpn_x_preferred":[
         "\u30e2\u30a2\u30ad\u30ed\u30a2\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Mvokillo"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u043e\u043a\u0438\u043b\u0441\u043a\u0438 \u0410\u0442\u043e\u043b"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:pon_x_preferred":[
         "Mwoakilloa"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u043e\u043a\u0438\u043b"
     ],
     "name:spa_x_preferred":[
         "Mokil"
@@ -93,7 +99,7 @@
         }
     ],
     "wof:id":890413013,
-    "wof:lastmodified":1566596168,
+    "wof:lastmodified":1690893331,
     "wof:name":"Mokil Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/417/413/890417413.geojson
+++ b/data/890/417/413/890417413.geojson
@@ -48,6 +48,9 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30e2\u30eb\u30af\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Namoluka"
+    ],
     "name:mkd_x_preferred":[
         "\u041d\u0430\u043c\u043e\u043b\u0443\u043a"
     ],
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890417413,
-    "wof:lastmodified":1566596177,
+    "wof:lastmodified":1690893339,
     "wof:name":"Namoluk Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/417/415/890417415.geojson
+++ b/data/890/417/415/890417415.geojson
@@ -48,6 +48,9 @@
     "name:jpn_x_preferred":[
         "\u30d5\u30a1\u30e6\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Faju"
+    ],
     "name:spa_x_preferred":[
         "Fayu"
     ],
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890417415,
-    "wof:lastmodified":1627522135,
+    "wof:lastmodified":1690893340,
     "wof:name":"Nomwin Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/417/417/890417417.geojson
+++ b/data/890/417/417/890417417.geojson
@@ -51,6 +51,12 @@
     "name:nld_x_preferred":[
         "Oneop"
     ],
+    "name:por_x_preferred":[
+        "Oneop"
+    ],
+    "name:spa_x_preferred":[
+        "Oneop"
+    ],
     "name:swe_x_preferred":[
         "Oneop"
     ],
@@ -90,7 +96,7 @@
         }
     ],
     "wof:id":890417417,
-    "wof:lastmodified":1566596178,
+    "wof:lastmodified":1690893340,
     "wof:name":"Oneop Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/417/425/890417425.geojson
+++ b/data/890/417/425/890417425.geojson
@@ -24,11 +24,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:aka_x_preferred":[
+        "Tetefo"
+    ],
     "name:ara_x_preferred":[
         "\u062a\u0627\u0631\u064a\u062e \u0642\u062f\u064a\u0645"
     ],
+    "name:arg_x_preferred":[
+        "Edat Antiga"
+    ],
     "name:ast_x_preferred":[
         "Ed\u00e1 Antigua"
+    ],
+    "name:azb_x_preferred":[
+        "\u0642\u062f\u06cc\u0645 \u062a\u0627\u0631\u06cc\u062e"
     ],
     "name:aze_x_preferred":[
         "Q\u0259dim D\u00fcnya"
@@ -41,6 +50,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09aa\u09cd\u09b0\u09be\u099a\u09c0\u09a8 \u0987\u09a4\u09bf\u09b9\u09be\u09b8"
+    ],
+    "name:ben_x_variant":[
+        "\u09aa\u09cd\u09b0\u09be\u099a\u09c0\u09a8\u0995\u09be\u09b2\u09c7\u09b0 \u0987\u09a4\u09bf\u09b9\u09be\u09b8"
     ],
     "name:bho_x_preferred":[
         "\u092a\u094d\u0930\u093e\u091a\u0940\u0928 \u0907\u0924\u093f\u0939\u093e\u0938"
@@ -63,20 +75,41 @@
     "name:ces_x_preferred":[
         "Starov\u011bk"
     ],
+    "name:ces_x_variant":[
+        "starov\u011bk"
+    ],
+    "name:chr_x_preferred":[
+        "\u13af\u13b8\u13af\u13f3\u13a2"
+    ],
     "name:chv_x_preferred":[
         "\u0410\u0432\u0430\u043b\u0445\u0438 \u0442\u0115\u043d\u0447\u0435"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0645\u06ce\u0698\u0648\u0648\u06cc \u062f\u06ce\u0631\u06cc\u0646"
+    ],
+    "name:cor_x_preferred":[
+        "Hen-Istori"
     ],
     "name:cym_x_preferred":[
         "Yr Henfyd"
     ],
+    "name:cym_x_variant":[
+        "yr henfyd"
+    ],
     "name:dan_x_preferred":[
         "Antikken"
+    ],
+    "name:dan_x_variant":[
+        "historisk oldtid"
     ],
     "name:deu_x_preferred":[
         "Altertum"
     ],
     "name:diq_x_preferred":[
         "Tarixo Antik"
+    ],
+    "name:dsb_x_preferred":[
+        "starow\u011bk"
     ],
     "name:ell_x_preferred":[
         "\u0391\u03c1\u03c7\u03b1\u03af\u03b1 \u0399\u03c3\u03c4\u03bf\u03c1\u03af\u03b1"
@@ -102,6 +135,9 @@
     "name:fin_x_preferred":[
         "Antiikki"
     ],
+    "name:fin_x_variant":[
+        "vanha aika"
+    ],
     "name:fra_x_preferred":[
         "Antiquit\u00e9"
     ],
@@ -111,11 +147,17 @@
     "name:fur_x_preferred":[
         "Storie antighe"
     ],
+    "name:gcr_x_preferred":[
+        "Antikit\u00e9"
+    ],
     "name:gle_x_preferred":[
         "An Chianaois"
     ],
     "name:glg_x_preferred":[
         "Idade Antiga"
+    ],
+    "name:grn_x_preferred":[
+        "\u00c1ra Ymaguare"
     ],
     "name:gsw_x_preferred":[
         "Altertum"
@@ -132,6 +174,9 @@
     "name:hrv_x_preferred":[
         "Stari vijek"
     ],
+    "name:hrv_x_variant":[
+        "stari vijek"
+    ],
     "name:hun_x_preferred":[
         "\u00f3kor"
     ],
@@ -140,6 +185,9 @@
     ],
     "name:ido_x_preferred":[
         "Antiqueso"
+    ],
+    "name:ile_x_preferred":[
+        "Ancian historie"
     ],
     "name:ina_x_preferred":[
         "Antiquitate"
@@ -155,6 +203,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u53e4\u4ee3"
+    ],
+    "name:kab_x_preferred":[
+        "Taglest"
     ],
     "name:kat_x_preferred":[
         "\u10eb\u10d5\u10d4\u10da\u10d8 \u10db\u10e1\u10dd\u10e4\u10da\u10d8\u10dd"
@@ -183,8 +234,14 @@
     "name:lfn_x_preferred":[
         "Anticia"
     ],
+    "name:lij_x_preferred":[
+        "Et\u00e6 Classica"
+    ],
     "name:lit_x_preferred":[
         "Senov\u0117s istorija"
+    ],
+    "name:lld_x_preferred":[
+        "Storia antica"
     ],
     "name:lmo_x_preferred":[
         "Et\u00e0 Ant\u00ecca"
@@ -201,11 +258,20 @@
     "name:mlg_x_preferred":[
         "Andro Taloha"
     ],
+    "name:mni_x_preferred":[
+        "\uabd1\uabc2\uabe4\uabc4 \uabc4\uabe8\uabcb\uabe5\uabc2\uabe4"
+    ],
+    "name:msa_x_preferred":[
+        "Sejarah purba"
+    ],
     "name:nan_x_preferred":[
         "K\u00f3\u0358-t\u0101i le\u030dk-s\u00fa"
     ],
     "name:nap_x_preferred":[
         "Et\u00e0 antica"
+    ],
+    "name:nep_x_preferred":[
+        "\u092a\u094d\u0930\u093e\u091a\u0940\u0928 \u0907\u0924\u093f\u0939\u093e\u0938"
     ],
     "name:nld_x_preferred":[
         "oudheid"
@@ -219,8 +285,14 @@
     "name:nov_x_preferred":[
         "Antiquitate"
     ],
+    "name:nqo_x_preferred":[
+        "\u07de\u07ca\u07ec\u07de\u07d8\u07d0\u07de\u07d8\u07d0"
+    ],
     "name:oci_x_preferred":[
         "Antiquitat"
+    ],
+    "name:pap_x_preferred":[
+        "Edat antiguo"
     ],
     "name:pcd_x_preferred":[
         "Antitchit\u00e8"
@@ -231,8 +303,17 @@
     "name:pol_x_preferred":[
         "Staro\u017cytno\u015b\u0107"
     ],
+    "name:pol_x_variant":[
+        "staro\u017cytno\u015b\u0107"
+    ],
     "name:por_x_preferred":[
         "hist\u00f3ria antiga"
+    ],
+    "name:pus_x_preferred":[
+        "\u0644\u0631\u063a\u0648\u0646\u06cc \u062a\u0627\u0631\u06cc\u062e"
+    ],
+    "name:roh_x_preferred":[
+        "Antica"
     ],
     "name:ron_x_preferred":[
         "Istoria antic\u0103"
@@ -242,6 +323,12 @@
     ],
     "name:rus_x_preferred":[
         "\u0414\u0440\u0435\u0432\u043d\u0438\u0439 \u043c\u0438\u0440"
+    ],
+    "name:rus_x_variant":[
+        "\u0434\u0440\u0435\u0432\u043d\u0438\u0439 \u043c\u0438\u0440"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c62\u1c5f\u1c68\u1c6e\u1c71 \u1c71\u1c5f\u1c5c\u1c5f\u1c62"
     ],
     "name:sco_x_preferred":[
         "auncient history"
@@ -255,14 +342,26 @@
     "name:slk_x_preferred":[
         "Starovek"
     ],
+    "name:slk_x_variant":[
+        "starovek"
+    ],
     "name:slv_x_preferred":[
         "Stari vek"
+    ],
+    "name:slv_x_variant":[
+        "stari vek"
     ],
     "name:spa_x_preferred":[
         "Historia antigua"
     ],
+    "name:spa_x_variant":[
+        "Edad Antigua"
+    ],
     "name:sqi_x_preferred":[
         "Alterturm"
+    ],
+    "name:srd_x_preferred":[
+        "Edade antiga"
     ],
     "name:srp_x_preferred":[
         "\u0410\u043d\u0442\u0438\u043a\u0430"
@@ -270,11 +369,17 @@
     "name:swe_x_preferred":[
         "Antiken"
     ],
+    "name:swe_x_variant":[
+        "f\u00f6rmedeltida historia"
+    ],
     "name:tam_x_preferred":[
         "\u0baa\u0ba3\u0bcd\u0b9f\u0bc8\u0baf \u0bb5\u0bb0\u0bb2\u0bbe\u0bb1\u0bc1"
     ],
     "name:tat_x_preferred":[
         "\u0411\u043e\u0440\u044b\u043d\u0433\u044b \u0434\u04e9\u043d\u044c\u044f"
+    ],
+    "name:tel_x_preferred":[
+        "\u0c2a\u0c4d\u0c30\u0c3e\u0c1a\u0c40\u0c28 \u0c1a\u0c30\u0c3f\u0c24\u0c4d\u0c30"
     ],
     "name:tgl_x_preferred":[
         "Sinaunang kasaysayan"
@@ -288,8 +393,17 @@
     "name:ukr_x_preferred":[
         "\u0421\u0442\u0430\u0440\u043e\u0434\u0430\u0432\u043d\u0456\u0439 \u0441\u0432\u0456\u0442"
     ],
+    "name:urd_x_preferred":[
+        "\u0642\u062f\u06cc\u0645 \u062a\u0627\u0631\u06cc\u062e"
+    ],
+    "name:uzb_x_preferred":[
+        "Qadimgi dunyo tarixi"
+    ],
     "name:vie_x_preferred":[
         "Th\u1eddi k\u1ef3 c\u1ed5 \u0111\u1ea1i"
+    ],
+    "name:vie_x_variant":[
+        "th\u1eddi k\u1ef3 c\u1ed5 \u0111\u1ea1i"
     ],
     "name:vro_x_preferred":[
         "Vanaaig"
@@ -348,7 +462,7 @@
         }
     ],
     "wof:id":890417425,
-    "wof:lastmodified":1566596177,
+    "wof:lastmodified":1690893339,
     "wof:name":"Pwene Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/417/431/890417431.geojson
+++ b/data/890/417/431/890417431.geojson
@@ -37,6 +37,9 @@
     "name:ita_x_preferred":[
         "Tamatam"
     ],
+    "name:jpn_x_preferred":[
+        "\u30bf\u30de\u30bf\u30e0\u5cf6"
+    ],
     "name:mkd_x_preferred":[
         "\u0422\u0430\u043c\u0430\u0442\u0430\u043c"
     ],
@@ -44,6 +47,9 @@
         "Tamatam"
     ],
     "name:pol_x_preferred":[
+        "Tamatam"
+    ],
+    "name:spa_x_preferred":[
         "Tamatam"
     ],
     "name:swe_x_preferred":[
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":890417431,
-    "wof:lastmodified":1566596178,
+    "wof:lastmodified":1690893340,
     "wof:name":"Tamatam Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/422/401/890422401.geojson
+++ b/data/890/422/401/890422401.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Kapingamarangi"
     ],
+    "name:ceb_x_preferred":[
+        "Kapingamarangi Atoll"
+    ],
     "name:ces_x_preferred":[
         "Kapingamarangi"
     ],
@@ -61,6 +64,9 @@
     "name:lat_x_preferred":[
         "Kapingamarangi"
     ],
+    "name:lav_x_preferred":[
+        "Kapinamarani"
+    ],
     "name:lit_x_preferred":[
         "Kapingamarangis"
     ],
@@ -75,6 +81,12 @@
     ],
     "name:spa_x_preferred":[
         "Kapingamarangi"
+    ],
+    "name:swe_x_preferred":[
+        "Kapingamarangi Atoll"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e01\u0e32\u0e1b\u0e35\u0e07\u0e32\u0e21\u0e32\u0e23\u0e32\u0e07\u0e35"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u043f\u0456\u043d\u0433\u0430\u043c\u0430\u0440\u0430\u043d\u0433\u0456"
@@ -111,7 +123,7 @@
         }
     ],
     "wof:id":890422401,
-    "wof:lastmodified":1566596167,
+    "wof:lastmodified":1690893330,
     "wof:name":"Kapingamarangi Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/422/415/890422415.geojson
+++ b/data/890/422/415/890422415.geojson
@@ -43,11 +43,20 @@
     "name:pol_x_preferred":[
         "Fanapanges"
     ],
+    "name:por_x_preferred":[
+        "Fala-Beguets"
+    ],
+    "name:spa_x_preferred":[
+        "Fanapanges"
+    ],
     "name:swe_x_preferred":[
         "Fanapanges Island"
     ],
     "name:und_x_variant":[
         "Kayo To"
+    ],
+    "name:zho_x_preferred":[
+        "\u6cd5\u62c9-\u8d1d\u76d6\u8328\u5c9b"
     ],
     "qs:name":"Fanapanges Island",
     "qs:photos_9r":0,
@@ -73,7 +82,7 @@
         }
     ],
     "wof:id":890422415,
-    "wof:lastmodified":1566596167,
+    "wof:lastmodified":1690893330,
     "wof:name":"Fanapanges Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/422/417/890422417.geojson
+++ b/data/890/422/417/890422417.geojson
@@ -43,6 +43,9 @@
     "name:jpn_x_preferred":[
         "\u30d5\u30a1\u30a4\u30b9\u5cf6"
     ],
+    "name:lav_x_preferred":[
+        "Faisa"
+    ],
     "name:mkd_x_preferred":[
         "\u0424\u0430\u0438\u0441"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:pol_x_preferred":[
         "Fais"
+    ],
+    "name:rus_x_preferred":[
+        "\u0424\u0430\u0438\u0441"
     ],
     "name:spa_x_preferred":[
         "Isla Fais"
@@ -97,7 +103,7 @@
         }
     ],
     "wof:id":890422417,
-    "wof:lastmodified":1566596167,
+    "wof:lastmodified":1690893331,
     "wof:name":"Fais Island",
     "wof:parent_id":85671227,
     "wof:placetype":"locality",

--- a/data/890/424/343/890424343.geojson
+++ b/data/890/424/343/890424343.geojson
@@ -36,6 +36,9 @@
     "name:cat_x_preferred":[
         "Kapingamarangi"
     ],
+    "name:ceb_x_preferred":[
+        "Kapingamarangi Atoll"
+    ],
     "name:ces_x_preferred":[
         "Kapingamarangi"
     ],
@@ -66,6 +69,9 @@
     "name:lat_x_preferred":[
         "Kapingamarangi"
     ],
+    "name:lav_x_preferred":[
+        "Kapinamarani"
+    ],
     "name:lit_x_preferred":[
         "Kapingamarangis"
     ],
@@ -80,6 +86,12 @@
     ],
     "name:spa_x_preferred":[
         "Kapingamarangi"
+    ],
+    "name:swe_x_preferred":[
+        "Kapingamarangi Atoll"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e01\u0e32\u0e1b\u0e35\u0e07\u0e32\u0e21\u0e32\u0e23\u0e32\u0e07\u0e35"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u043f\u0456\u043d\u0433\u0430\u043c\u0430\u0440\u0430\u043d\u0433\u0456"
@@ -123,7 +135,7 @@
         }
     ],
     "wof:id":890424343,
-    "wof:lastmodified":1566596173,
+    "wof:lastmodified":1690893336,
     "wof:name":"Kapingamarangi Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/345/890424345.geojson
+++ b/data/890/424/345/890424345.geojson
@@ -36,6 +36,9 @@
     "name:ita_x_preferred":[
         "Kitti"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ad\u30c3\u30c6\u30a3"
+    ],
     "name:mkd_x_preferred":[
         "\u041a\u0438\u0442\u0438"
     ],
@@ -43,6 +46,12 @@
         "Kitti"
     ],
     "name:pol_x_preferred":[
+        "Kitti"
+    ],
+    "name:por_x_preferred":[
+        "Kitti"
+    ],
+    "name:spa_x_preferred":[
         "Kitti"
     ],
     "qs:name":"Kitti Municipality",
@@ -81,7 +90,7 @@
         }
     ],
     "wof:id":890424345,
-    "wof:lastmodified":1566596173,
+    "wof:lastmodified":1690893335,
     "wof:name":"Kitti Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/347/890424347.geojson
+++ b/data/890/424/347/890424347.geojson
@@ -24,16 +24,58 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:afr_x_preferred":[
+        "Kolonia"
+    ],
+    "name:arg_x_preferred":[
+        "Kolonia"
+    ],
+    "name:ary_x_preferred":[
+        "\u0643\u0627\u0648\u0644\u0648\u0646\u064a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Kolonia"
+    ],
+    "name:bar_x_preferred":[
+        "Kolonia"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0430\u043b\u043e\u043d\u0456\u044f"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0430\u043b\u043e\u043d\u0456\u044f"
     ],
     "name:bod_x_preferred":[
         "\u0f41\u0f7c\u0f0b\u0f63\u0f7c\u0f0b\u0f49\u0f72\u0f0b\u0f61\u0f0d"
     ],
+    "name:bos_x_preferred":[
+        "Kolonia"
+    ],
+    "name:bre_x_preferred":[
+        "Kolonia"
+    ],
     "name:bul_x_preferred":[
         "\u041a\u043e\u043b\u043e\u043d\u0438\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Kolonia"
+    ],
     "name:ceb_x_preferred":[
+        "Kolonia"
+    ],
+    "name:ces_x_preferred":[
+        "Kolonia"
+    ],
+    "name:cor_x_preferred":[
+        "Kolonia"
+    ],
+    "name:cos_x_preferred":[
+        "Kolonia"
+    ],
+    "name:cym_x_preferred":[
+        "Kolonia"
+    ],
+    "name:dan_x_preferred":[
         "Kolonia"
     ],
     "name:deu_x_preferred":[
@@ -45,14 +87,50 @@
     "name:epo_x_preferred":[
         "Kolonio"
     ],
+    "name:est_x_preferred":[
+        "Kolonia"
+    ],
+    "name:eus_x_preferred":[
+        "Kolonia"
+    ],
+    "name:fao_x_preferred":[
+        "Kolonia"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0644\u0648\u0646\u06cc\u0627"
+    ],
+    "name:fin_x_preferred":[
+        "Kolonia"
     ],
     "name:fra_x_preferred":[
         "Kolonia"
     ],
+    "name:gla_x_preferred":[
+        "Kolonia"
+    ],
+    "name:gle_x_preferred":[
+        "Kolonia"
+    ],
+    "name:glg_x_preferred":[
+        "Kolonia"
+    ],
+    "name:glv_x_preferred":[
+        "Kolonia"
+    ],
     "name:heb_x_preferred":[
         "\u05e7\u05d5\u05dc\u05d5\u05e0\u05d9\u05d4"
+    ],
+    "name:hrv_x_preferred":[
+        "Kolonia"
+    ],
+    "name:hun_x_preferred":[
+        "Kolonia"
+    ],
+    "name:ind_x_preferred":[
+        "Kolonia"
+    ],
+    "name:isl_x_preferred":[
+        "Kolonia"
     ],
     "name:ita_x_preferred":[
         "Kolonia"
@@ -63,16 +141,37 @@
     "name:kor_x_preferred":[
         "\ucf5c\ub85c\ub2c8\uc544"
     ],
+    "name:lav_x_preferred":[
+        "Kolonia"
+    ],
     "name:lit_x_preferred":[
         "Kolonija"
     ],
+    "name:ltz_x_preferred":[
+        "Kolonia"
+    ],
     "name:mkd_x_preferred":[
         "\u041a\u043e\u043b\u043e\u043d\u0438\u0458\u0430"
+    ],
+    "name:mlt_x_preferred":[
+        "Kolonia"
     ],
     "name:nds_x_preferred":[
         "Kolonia"
     ],
     "name:nld_x_preferred":[
+        "Kolonia"
+    ],
+    "name:nno_x_preferred":[
+        "Kolonia"
+    ],
+    "name:nrm_x_preferred":[
+        "Kolonia"
+    ],
+    "name:oci_x_preferred":[
+        "Kolonia"
+    ],
+    "name:pms_x_preferred":[
         "Kolonia"
     ],
     "name:pol_x_preferred":[
@@ -81,13 +180,25 @@
     "name:por_x_preferred":[
         "Kolonia"
     ],
+    "name:roh_x_preferred":[
+        "Kolonia"
+    ],
     "name:ron_x_preferred":[
         "Kolonia"
     ],
     "name:rus_x_preferred":[
         "\u041a\u043e\u043b\u043e\u043d\u0438\u0430"
     ],
+    "name:slk_x_preferred":[
+        "Kolonia"
+    ],
+    "name:slv_x_preferred":[
+        "Kolonia"
+    ],
     "name:spa_x_preferred":[
+        "Kolonia"
+    ],
+    "name:sqi_x_preferred":[
         "Kolonia"
     ],
     "name:srp_x_preferred":[
@@ -96,14 +207,26 @@
     "name:swe_x_preferred":[
         "Kolonia"
     ],
+    "name:tah_x_preferred":[
+        "Kolonia"
+    ],
     "name:tha_x_preferred":[
         "\u0e42\u0e04\u0e42\u0e25\u0e40\u0e19\u0e35\u0e22"
+    ],
+    "name:tur_x_preferred":[
+        "Kolonia"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u043b\u043e\u043d\u0456\u044f"
     ],
+    "name:wln_x_preferred":[
+        "Kolonia"
+    ],
     "name:zho_x_preferred":[
         "\u79d1\u6d1b\u5c3c\u4e9a"
+    ],
+    "name:zul_x_preferred":[
+        "Kolonia"
     ],
     "qs:name":"Kolonia Municipality",
     "qs:photos_9r":0,
@@ -145,7 +268,7 @@
         }
     ],
     "wof:id":890424347,
-    "wof:lastmodified":1566596172,
+    "wof:lastmodified":1690893334,
     "wof:name":"Kolonia Municipality",
     "wof:parent_id":85671217,
     "wof:placetype":"county",

--- a/data/890/424/355/890424355.geojson
+++ b/data/890/424/355/890424355.geojson
@@ -51,6 +51,18 @@
     "name:pol_x_preferred":[
         "Nett"
     ],
+    "name:por_x_preferred":[
+        "Nett"
+    ],
+    "name:rus_x_preferred":[
+        "\u041d\u0435\u0442\u0442"
+    ],
+    "name:spa_x_preferred":[
+        "Nett"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041d\u0435\u0442\u0442"
+    ],
     "qs:name":"Nett Municipality",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -91,7 +103,7 @@
         }
     ],
     "wof:id":890424355,
-    "wof:lastmodified":1566596171,
+    "wof:lastmodified":1690893333,
     "wof:name":"Nett Municipality",
     "wof:parent_id":85671217,
     "wof:placetype":"county",

--- a/data/890/424/357/890424357.geojson
+++ b/data/890/424/357/890424357.geojson
@@ -30,6 +30,12 @@
     "name:ceb_x_preferred":[
         "Rull Municipality"
     ],
+    "name:cym_x_preferred":[
+        "Rull"
+    ],
+    "name:deu_x_preferred":[
+        "Rull"
+    ],
     "name:eng_x_preferred":[
         "Rull"
     ],
@@ -39,8 +45,14 @@
     "name:fra_x_preferred":[
         "Municipalit\u00e9 de Rull"
     ],
+    "name:fra_x_variant":[
+        "Rull"
+    ],
     "name:jpn_x_preferred":[
         "\u30eb\u30eb"
+    ],
+    "name:spa_x_preferred":[
+        "Rull"
     ],
     "name:swe_x_preferred":[
         "Rull Municipality"
@@ -85,7 +97,7 @@
         }
     ],
     "wof:id":890424357,
-    "wof:lastmodified":1627522135,
+    "wof:lastmodified":1690893335,
     "wof:name":"Rull Municipality",
     "wof:parent_id":85671227,
     "wof:placetype":"county",

--- a/data/890/424/359/890424359.geojson
+++ b/data/890/424/359/890424359.geojson
@@ -33,6 +33,9 @@
     "name:fra_x_preferred":[
         "Municipalit\u00e9 de Rumung"
     ],
+    "name:fra_x_variant":[
+        "Rumung"
+    ],
     "name:ita_x_preferred":[
         "Rumung"
     ],
@@ -41,6 +44,9 @@
     ],
     "name:nld_x_preferred":[
         "Rumung"
+    ],
+    "name:zho_x_preferred":[
+        "\u9b6f\u8499\u5cf6"
     ],
     "qs:name":"Rumung Municipality",
     "qs:photos_9r":0,
@@ -80,7 +86,7 @@
         }
     ],
     "wof:id":890424359,
-    "wof:lastmodified":1627522135,
+    "wof:lastmodified":1690893335,
     "wof:name":"Rumung Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/361/890424361.geojson
+++ b/data/890/424/361/890424361.geojson
@@ -42,8 +42,14 @@
     "name:fra_x_preferred":[
         "Piagailoe"
     ],
+    "name:ita_x_preferred":[
+        "Piagailoe"
+    ],
     "name:jpn_x_preferred":[
         "\u30d4\u30a2\u30ac\u30a4\u30ed\u30a8\u74b0\u7901"
+    ],
+    "name:lav_x_preferred":[
+        "Rietumfaju"
     ],
     "name:nld_x_preferred":[
         "Piagailoe"
@@ -53,6 +59,9 @@
     ],
     "name:spa_x_preferred":[
         "Piagailoe"
+    ],
+    "name:spa_x_variant":[
+        "Fayu Oriental"
     ],
     "name:swe_x_preferred":[
         "West Fayu Atoll"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":890424361,
-    "wof:lastmodified":1566596172,
+    "wof:lastmodified":1690893334,
     "wof:name":"Satawal Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/363/890424363.geojson
+++ b/data/890/424/363/890424363.geojson
@@ -24,6 +24,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:deu_x_preferred":[
+        "Tomil"
+    ],
     "name:eng_x_preferred":[
         "Tomil"
     ],
@@ -33,6 +36,9 @@
     "name:fra_x_preferred":[
         "Municipalit\u00e9 de Tomil"
     ],
+    "name:fra_x_variant":[
+        "Tomil"
+    ],
     "name:ita_x_preferred":[
         "Tomil"
     ],
@@ -40,6 +46,9 @@
         "Tomil"
     ],
     "name:pol_x_preferred":[
+        "Tomil"
+    ],
+    "name:spa_x_preferred":[
         "Tomil"
     ],
     "qs:name":"Tomil Municipality",
@@ -78,7 +87,7 @@
         }
     ],
     "wof:id":890424363,
-    "wof:lastmodified":1627522135,
+    "wof:lastmodified":1690893333,
     "wof:name":"Tomil Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/365/890424365.geojson
+++ b/data/890/424/365/890424365.geojson
@@ -24,6 +24,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ast_x_preferred":[
+        "Ulithi"
+    ],
     "name:ceb_x_preferred":[
         "Ulithi Atoll"
     ],
@@ -54,6 +57,12 @@
     "name:jpn_x_preferred":[
         "\u30a6\u30eb\u30b7\u30fc\u74b0\u7901"
     ],
+    "name:kor_x_preferred":[
+        "\uc6b8\ub9ac\uc2dc \ud658\ucd08"
+    ],
+    "name:lav_x_preferred":[
+        "Uliti"
+    ],
     "name:lit_x_preferred":[
         "Ulitis"
     ],
@@ -77,6 +86,9 @@
     ],
     "name:swe_x_preferred":[
         "Ulithi Atoll"
+    ],
+    "name:tur_x_preferred":[
+        "Ulithi"
     ],
     "name:zho_x_preferred":[
         "\u70cf\u5229\u897f\u74b0\u7901"
@@ -117,7 +129,7 @@
         }
     ],
     "wof:id":890424365,
-    "wof:lastmodified":1566596171,
+    "wof:lastmodified":1690893333,
     "wof:name":"Ulithi Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/371/890424371.geojson
+++ b/data/890/424/371/890424371.geojson
@@ -54,6 +54,12 @@
     "name:jpn_x_preferred":[
         "\u30a6\u30a9\u30ec\u30a2\u30a4\u74b0\u7901"
     ],
+    "name:kor_x_preferred":[
+        "\uc6d4\ub808\uc544\uc774 \ud658\ucd08"
+    ],
+    "name:lav_x_preferred":[
+        "Vol\u0113i"
+    ],
     "name:lit_x_preferred":[
         "Voleai"
     ],
@@ -76,6 +82,12 @@
         "Woleai"
     ],
     "name:swe_x_preferred":[
+        "Woleai"
+    ],
+    "name:tur_x_preferred":[
+        "Woleai"
+    ],
+    "name:vie_x_preferred":[
         "Woleai"
     ],
     "name:wuu_x_preferred":[
@@ -123,7 +135,7 @@
         }
     ],
     "wof:id":890424371,
-    "wof:lastmodified":1566596172,
+    "wof:lastmodified":1690893334,
     "wof:name":"Woleai Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/373/890424373.geojson
+++ b/data/890/424/373/890424373.geojson
@@ -42,10 +42,16 @@
     "name:jpn_x_preferred":[
         "\u68ee\u5c0f\u5f01"
     ],
+    "name:pap_x_preferred":[
+        "Mori Koben"
+    ],
     "name:rus_x_preferred":[
         "\u041c\u043e\u0440\u0438"
     ],
     "name:spa_x_preferred":[
+        "Mori Koben"
+    ],
+    "name:sqi_x_preferred":[
         "Mori Koben"
     ],
     "qs:name":"Eot Municipality",
@@ -84,7 +90,7 @@
         }
     ],
     "wof:id":890424373,
-    "wof:lastmodified":1627522135,
+    "wof:lastmodified":1690893336,
     "wof:name":"Eot Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/377/890424377.geojson
+++ b/data/890/424/377/890424377.geojson
@@ -48,6 +48,12 @@
     "name:nld_x_preferred":[
         "Fananu"
     ],
+    "name:por_x_preferred":[
+        "Fananu"
+    ],
+    "name:spa_x_preferred":[
+        "Fananu"
+    ],
     "name:swe_x_preferred":[
         "Fananu"
     ],
@@ -90,7 +96,7 @@
         }
     ],
     "wof:id":890424377,
-    "wof:lastmodified":1566596171,
+    "wof:lastmodified":1690893334,
     "wof:name":"Fananu Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/379/890424379.geojson
+++ b/data/890/424/379/890424379.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Pulap"
+    ],
     "name:ceb_x_preferred":[
         "Pollap"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d7\u30f3\u30ca\u30c3\u30d7\u5cf6"
+    ],
+    "name:lav_x_preferred":[
+        "Pulapa"
     ],
     "name:mkd_x_preferred":[
         "\u041f\u0443\u043b\u0430\u043f"
@@ -81,7 +87,7 @@
         }
     ],
     "wof:id":890424379,
-    "wof:lastmodified":1566596171,
+    "wof:lastmodified":1690893334,
     "wof:name":"Pulap Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/381/890424381.geojson
+++ b/data/890/424/381/890424381.geojson
@@ -46,6 +46,12 @@
     "name:nld_x_preferred":[
         "Pisaras"
     ],
+    "name:por_x_preferred":[
+        "Pisaras"
+    ],
+    "name:spa_x_preferred":[
+        "Pisaras"
+    ],
     "name:swe_x_preferred":[
         "Pisaras"
     ],
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":890424381,
-    "wof:lastmodified":1566596173,
+    "wof:lastmodified":1690893336,
     "wof:name":"Pisaras Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/703/890424703.geojson
+++ b/data/890/424/703/890424703.geojson
@@ -43,6 +43,9 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30e2\u30eb\u30af\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Namoluka"
+    ],
     "name:mkd_x_preferred":[
         "\u041d\u0430\u043c\u043e\u043b\u0443\u043a"
     ],
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890424703,
-    "wof:lastmodified":1566596172,
+    "wof:lastmodified":1690893335,
     "wof:name":"Oneop Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/707/890424707.geojson
+++ b/data/890/424/707/890424707.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0625\u0631\u0627\u0641\u0627\u0646"
+    ],
+    "name:asm_x_preferred":[
+        "\u0987\u09f0\u09be\u09f1\u09be\u09a8"
+    ],
     "name:ben_x_preferred":[
         "\u0987\u09b0\u09be\u09ac\u09be\u09a8"
     ],
@@ -69,6 +75,9 @@
     ],
     "name:nld_x_preferred":[
         "Iravan"
+    ],
+    "name:pan_x_preferred":[
+        "\u0a08\u0a30\u0a3e\u0a35\u0a28"
     ],
     "name:pol_x_preferred":[
         "Arawan"
@@ -123,7 +132,7 @@
         }
     ],
     "wof:id":890424707,
-    "wof:lastmodified":1566596171,
+    "wof:lastmodified":1690893333,
     "wof:name":"Kuttu Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/731/890428731.geojson
+++ b/data/890/428/731/890428731.geojson
@@ -40,6 +40,12 @@
     "name:mkd_x_preferred":[
         "\u041e\u043d\u043e"
     ],
+    "name:por_x_preferred":[
+        "Onou"
+    ],
+    "name:spa_x_preferred":[
+        "Ono"
+    ],
     "name:swe_x_preferred":[
         "Onou"
     ],
@@ -70,7 +76,7 @@
         }
     ],
     "wof:id":890428731,
-    "wof:lastmodified":1566596177,
+    "wof:lastmodified":1690893339,
     "wof:name":"Onou",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/689/890429689.geojson
+++ b/data/890/429/689/890429689.geojson
@@ -24,6 +24,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:cat_x_preferred":[
+        "Ngulu"
+    ],
     "name:ceb_x_preferred":[
         "Ngulu Atoll"
     ],
@@ -50,6 +53,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30cc\u30b0\u30fc\u30eb\u74b0\u7901"
+    ],
+    "name:lav_x_preferred":[
+        "Nulu"
     ],
     "name:lit_x_preferred":[
         "Ngulu"
@@ -105,7 +111,7 @@
         }
     ],
     "wof:id":890429689,
-    "wof:lastmodified":1566596178,
+    "wof:lastmodified":1690893340,
     "wof:name":"Ngulu Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/691/890429691.geojson
+++ b/data/890/429/691/890429691.geojson
@@ -54,6 +54,9 @@
     "name:kor_x_preferred":[
         "\uc0ac\ud0c0\uc644 \ud658\ucd08"
     ],
+    "name:lav_x_preferred":[
+        "Satavana"
+    ],
     "name:lit_x_preferred":[
         "Satavanas"
     ],
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890429691,
-    "wof:lastmodified":1566596179,
+    "wof:lastmodified":1690893341,
     "wof:name":"Kuttu Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/695/890429695.geojson
+++ b/data/890/429/695/890429695.geojson
@@ -48,6 +48,9 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30e2\u30cc\u30a4\u30c8\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Namonuito"
+    ],
     "name:lit_x_preferred":[
         "Namonuito atolas"
     ],
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":890429695,
-    "wof:lastmodified":1566596179,
+    "wof:lastmodified":1690893340,
     "wof:name":"Makur Municipality",
     "wof:parent_id":85671221,
     "wof:placetype":"county",

--- a/data/890/429/799/890429799.geojson
+++ b/data/890/429/799/890429799.geojson
@@ -43,6 +43,12 @@
     "name:nld_x_preferred":[
         "Fananu"
     ],
+    "name:por_x_preferred":[
+        "Fananu"
+    ],
+    "name:spa_x_preferred":[
+        "Fananu"
+    ],
     "name:swe_x_preferred":[
         "Fananu"
     ],
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":890429799,
-    "wof:lastmodified":1566596178,
+    "wof:lastmodified":1690893340,
     "wof:name":"Fananu Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/801/890429801.geojson
+++ b/data/890/429/801/890429801.geojson
@@ -46,6 +46,9 @@
     "name:pol_x_preferred":[
         "Ruo"
     ],
+    "name:spa_x_preferred":[
+        "Ruo"
+    ],
     "name:swe_x_preferred":[
         "Ruo"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890429801,
-    "wof:lastmodified":1566596179,
+    "wof:lastmodified":1690893341,
     "wof:name":"Ruo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/433/267/890433267.geojson
+++ b/data/890/433/267/890433267.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:ary_x_preferred":[
+        "\u0648\u064a\u0646\u0648"
+    ],
+    "name:cat_x_preferred":[
+        "Weno"
+    ],
     "name:ceb_x_preferred":[
         "Weno Town"
+    ],
+    "name:ces_x_preferred":[
+        "Weno"
     ],
     "name:deu_x_preferred":[
         "Weno"
@@ -49,6 +58,9 @@
     "name:heb_x_variant":[
         "\u05d5\u05e0\u05d5"
     ],
+    "name:ind_x_preferred":[
+        "Weno"
+    ],
     "name:ita_x_preferred":[
         "Weno"
     ],
@@ -57,6 +69,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc6e8\ub178"
+    ],
+    "name:lav_x_preferred":[
+        "Veno"
     ],
     "name:lit_x_preferred":[
         "Venas"
@@ -82,6 +97,9 @@
     "name:rus_x_preferred":[
         "\u0412\u0435\u043d\u043e"
     ],
+    "name:slk_x_preferred":[
+        "Weno"
+    ],
     "name:spa_x_preferred":[
         "Weno"
     ],
@@ -93,6 +111,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e27\u0e42\u0e19"
+    ],
+    "name:tur_x_preferred":[
+        "Weno"
     ],
     "name:ukr_x_preferred":[
         "\u0412\u0435\u043d\u043e"
@@ -128,7 +149,7 @@
         }
     ],
     "wof:id":890433267,
-    "wof:lastmodified":1566596182,
+    "wof:lastmodified":1690893344,
     "wof:name":"Weno Town",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/639/890435639.geojson
+++ b/data/890/435/639/890435639.geojson
@@ -51,6 +51,9 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30d7\u30a5\u30a2\u30d5\u30a3\u30af\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Sjapvu\u0101fika"
+    ],
     "name:mkd_x_preferred":[
         "\u0421\u0430\u043f\u0432\u0443\u0430\u0445\u0444\u0443\u043a"
     ],
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":890435639,
-    "wof:lastmodified":1566596182,
+    "wof:lastmodified":1690893345,
     "wof:name":"Ngatik Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/435/643/890435643.geojson
+++ b/data/890/435/643/890435643.geojson
@@ -33,6 +33,12 @@
     "name:aze_x_preferred":[
         "Nukuoro atollu"
     ],
+    "name:bel_x_preferred":[
+        "\u041d\u0443\u043a\u0443\u043e\u0440\u0430"
+    ],
+    "name:cat_x_preferred":[
+        "Nukuoro"
+    ],
     "name:ceb_x_preferred":[
         "Nukuoro Atoll"
     ],
@@ -60,6 +66,9 @@
     "name:lat_x_preferred":[
         "Nukuoro"
     ],
+    "name:lav_x_preferred":[
+        "Nukuoro"
+    ],
     "name:lit_x_preferred":[
         "Nukuoras"
     ],
@@ -81,8 +90,17 @@
     "name:swe_x_preferred":[
         "Nukuoro Atoll"
     ],
+    "name:tha_x_preferred":[
+        "\u0e19\u0e39\u0e01\u0e39\u0e42\u0e2d\u0e42\u0e23"
+    ],
     "name:ukr_x_preferred":[
         "\u041d\u0443\u043a\u0443\u043e\u0440\u043e"
+    ],
+    "name:urd_x_preferred":[
+        "\u0646\u0648\u06a9\u0624\u0631\u0648"
+    ],
+    "name:vie_x_preferred":[
+        "Nukuoro"
     ],
     "name:zho_x_preferred":[
         "\u52aa\u5eab\u5967\u7f85\u74b0\u7901"
@@ -123,7 +141,7 @@
         }
     ],
     "wof:id":890435643,
-    "wof:lastmodified":1566596182,
+    "wof:lastmodified":1690893344,
     "wof:name":"Nukuoro Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/436/353/890436353.geojson
+++ b/data/890/436/353/890436353.geojson
@@ -24,6 +24,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ceb_x_preferred":[
+        "Gagil Municipality"
+    ],
+    "name:deu_x_preferred":[
+        "Gagil"
+    ],
     "name:eng_x_preferred":[
         "Gagil"
     ],
@@ -41,6 +47,15 @@
     ],
     "name:pol_x_preferred":[
         "Gagil"
+    ],
+    "name:spa_x_preferred":[
+        "Gagil"
+    ],
+    "name:swe_x_preferred":[
+        "Gagil Municipality"
+    ],
+    "name:zho_x_preferred":[
+        "\u52a0\u5409\u723e\u5cf6"
     ],
     "qs:name":"Gagil Municipality",
     "qs:photos_9r":0,
@@ -78,7 +93,7 @@
         }
     ],
     "wof:id":890436353,
-    "wof:lastmodified":1566596175,
+    "wof:lastmodified":1690893337,
     "wof:name":"Gagil Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/436/355/890436355.geojson
+++ b/data/890/436/355/890436355.geojson
@@ -24,6 +24,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ceb_x_preferred":[
+        "Kanifay Municipality"
+    ],
     "name:eng_x_preferred":[
         "Kanifay"
     ],
@@ -38,6 +41,12 @@
     ],
     "name:nld_x_preferred":[
         "Kanifay"
+    ],
+    "name:spa_x_preferred":[
+        "Kanifay"
+    ],
+    "name:swe_x_preferred":[
+        "Kanifay Municipality"
     ],
     "qs:name":"Kanifay Municipality",
     "qs:photos_9r":0,
@@ -77,7 +86,7 @@
         }
     ],
     "wof:id":890436355,
-    "wof:lastmodified":1566596175,
+    "wof:lastmodified":1690893337,
     "wof:name":"Kanifay Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/571/890442571.geojson
+++ b/data/890/442/571/890442571.geojson
@@ -39,6 +39,9 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30e2\u30cc\u30a4\u30c8\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Namonuito"
+    ],
     "name:lit_x_preferred":[
         "Namonuito atolas"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890442571,
-    "wof:lastmodified":1566596179,
+    "wof:lastmodified":1690893342,
     "wof:name":"Onoun Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/573/890442573.geojson
+++ b/data/890/442/573/890442573.geojson
@@ -27,6 +27,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0644\u0627\u064a\u0629 \u062a\u0634\u0648\u0643"
     ],
+    "name:ary_x_preferred":[
+        "\u0648\u064a\u0644\u0627\u064a\u0629 \u062a\u0634\u0648\u0648\u0643"
+    ],
     "name:bel_x_preferred":[
         "\u0410\u0441\u0442\u0440\u0430\u0432\u044b \u0427\u0443\u045e\u043a"
     ],
@@ -55,13 +58,17 @@
         "Param"
     ],
     "name:eng_x_variant":[
-        "Chuuk State"
+        "Chuuk State",
+        "Chuuk"
     ],
     "name:epo_x_preferred":[
         "Chuuk"
     ],
     "name:est_x_preferred":[
         "Chuuki saared"
+    ],
+    "name:eus_x_preferred":[
+        "Chuuk"
     ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0627\u0644\u062a \u0686\u0648\u06a9"
@@ -70,6 +77,9 @@
         "Chuuk"
     ],
     "name:fra_x_preferred":[
+        "Chuuk"
+    ],
+    "name:frr_x_preferred":[
         "Chuuk"
     ],
     "name:glg_x_preferred":[
@@ -83,6 +93,9 @@
     ],
     "name:hin_x_preferred":[
         "\u091a\u0942\u0915 \u0930\u093e\u091c\u094d\u092f"
+    ],
+    "name:hrv_x_preferred":[
+        "Chuuk"
     ],
     "name:ind_x_preferred":[
         "Chuuk"
@@ -117,6 +130,9 @@
     "name:msa_x_preferred":[
         "Chuuk State"
     ],
+    "name:nan_x_preferred":[
+        "Chuuk Chiu"
+    ],
     "name:nld_x_preferred":[
         "Chuuk"
     ],
@@ -137,6 +153,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0422\u0440\u0443\u043a"
+    ],
+    "name:rus_x_variant":[
+        "\u0427\u0443\u0443\u043a"
     ],
     "name:sin_x_preferred":[
         "\u0da0\u0d9a\u0dca \u0dbb\u0dcf\u0da2\u0dca\u200d\u0dba"
@@ -174,11 +193,20 @@
     "name:wuu_x_preferred":[
         "\u695a\u514b\u5dde"
     ],
+    "name:wuu_x_variant":[
+        "\u4e18\u514b\u5dde"
+    ],
     "name:yue_x_preferred":[
         "\u695a\u514b\u5dde"
     ],
+    "name:yue_x_variant":[
+        "\u4e18\u514b\u5dde"
+    ],
     "name:zho_x_preferred":[
         "\u695a\u514b"
+    ],
+    "name:zho_x_variant":[
+        "\u4e18\u514b\u5dde"
     ],
     "qs:name":"Parem Municipality",
     "qs:photos_9r":0,
@@ -216,7 +244,7 @@
         }
     ],
     "wof:id":890442573,
-    "wof:lastmodified":1566596179,
+    "wof:lastmodified":1690893341,
     "wof:name":"Parem Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/749/890442749.geojson
+++ b/data/890/442/749/890442749.geojson
@@ -54,6 +54,9 @@
     "name:kor_x_preferred":[
         "\uc0ac\ud0c0\uc644 \ud658\ucd08"
     ],
+    "name:lav_x_preferred":[
+        "Satavana"
+    ],
     "name:lit_x_preferred":[
         "Satavanas"
     ],
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890442749,
-    "wof:lastmodified":1566596179,
+    "wof:lastmodified":1690893341,
     "wof:name":"Moch Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/313/890445313.geojson
+++ b/data/890/445/313/890445313.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":-1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Uman"
+    ],
     "name:ceb_x_preferred":[
         "Uman Island"
     ],
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":890445313,
-    "wof:lastmodified":1566596180,
+    "wof:lastmodified":1690893342,
     "wof:name":"Uman Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/323/890445323.geojson
+++ b/data/890/445/323/890445323.geojson
@@ -37,6 +37,9 @@
     "name:ita_x_preferred":[
         "Tamatam"
     ],
+    "name:jpn_x_preferred":[
+        "\u30bf\u30de\u30bf\u30e0\u5cf6"
+    ],
     "name:mkd_x_preferred":[
         "\u0422\u0430\u043c\u0430\u0442\u0430\u043c"
     ],
@@ -44,6 +47,9 @@
         "Tamatam"
     ],
     "name:pol_x_preferred":[
+        "Tamatam"
+    ],
+    "name:spa_x_preferred":[
         "Tamatam"
     ],
     "name:swe_x_preferred":[
@@ -78,7 +84,7 @@
         }
     ],
     "wof:id":890445323,
-    "wof:lastmodified":1566596180,
+    "wof:lastmodified":1690893342,
     "wof:name":"Tamatam",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/773/890445773.geojson
+++ b/data/890/445/773/890445773.geojson
@@ -42,6 +42,9 @@
     "name:ita_x_preferred":[
         "Tamatam"
     ],
+    "name:jpn_x_preferred":[
+        "\u30bf\u30de\u30bf\u30e0\u5cf6"
+    ],
     "name:mkd_x_preferred":[
         "\u0422\u0430\u043c\u0430\u0442\u0430\u043c"
     ],
@@ -49,6 +52,9 @@
         "Tamatam"
     ],
     "name:pol_x_preferred":[
+        "Tamatam"
+    ],
+    "name:spa_x_preferred":[
         "Tamatam"
     ],
     "name:swe_x_preferred":[
@@ -90,7 +96,7 @@
         }
     ],
     "wof:id":890445773,
-    "wof:lastmodified":1566596181,
+    "wof:lastmodified":1690893343,
     "wof:name":"Tamatam Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/777/890445777.geojson
+++ b/data/890/445/777/890445777.geojson
@@ -18,11 +18,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":6.0,
+    "name:ara_x_preferred":[
+        "\u062a\u0634\u0648\u0643 \u0644\u0627\u063a\u0648\u0646"
+    ],
     "name:bel_x_preferred":[
         "\u0427\u0443\u045e\u043a"
     ],
+    "name:cat_x_preferred":[
+        "atol Chuuk"
+    ],
     "name:ceb_x_preferred":[
         "Chuuk Lagoon"
+    ],
+    "name:dan_x_preferred":[
+        "Chuuk"
     ],
     "name:deu_x_preferred":[
         "Chuuk"
@@ -60,6 +69,12 @@
     "name:kor_x_preferred":[
         "\ucd94\ud06c \uc81c\ub3c4"
     ],
+    "name:kor_x_variant":[
+        "\ucd94\ud06c \ub77c\uad70"
+    ],
+    "name:lav_x_preferred":[
+        "\u010c\u016bka"
+    ],
     "name:lit_x_preferred":[
         "\u010ciuko lag\u016bna"
     ],
@@ -69,8 +84,17 @@
     "name:pol_x_preferred":[
         "Chuuk"
     ],
+    "name:por_x_preferred":[
+        "Chuuk Lagoon"
+    ],
     "name:rus_x_preferred":[
         "\u0422\u0440\u0443\u043a"
+    ],
+    "name:slk_x_preferred":[
+        "\u010cuk lag\u00fana"
+    ],
+    "name:spa_x_preferred":[
+        "Islas Chuuk"
     ],
     "name:swe_x_preferred":[
         "Chuuk Lagoon"
@@ -113,7 +137,7 @@
         }
     ],
     "wof:id":890445777,
-    "wof:lastmodified":1566596180,
+    "wof:lastmodified":1690893342,
     "wof:name":"Tonoas Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/787/890445787.geojson
+++ b/data/890/445/787/890445787.geojson
@@ -40,6 +40,12 @@
     "name:nld_x_preferred":[
         "Sokehs"
     ],
+    "name:por_x_preferred":[
+        "Sokehs"
+    ],
+    "name:spa_x_preferred":[
+        "Sokehs"
+    ],
     "name:swe_x_preferred":[
         "Sokehs Municipality"
     ],
@@ -69,7 +75,7 @@
         }
     ],
     "wof:id":890445787,
-    "wof:lastmodified":1566596181,
+    "wof:lastmodified":1690893343,
     "wof:name":"Mokil Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/793/890445793.geojson
+++ b/data/890/445/793/890445793.geojson
@@ -43,6 +43,9 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30e2\u30eb\u30af\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Namoluka"
+    ],
     "name:mkd_x_preferred":[
         "\u041d\u0430\u043c\u043e\u043b\u0443\u043a"
     ],
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890445793,
-    "wof:lastmodified":1566596181,
+    "wof:lastmodified":1690893342,
     "wof:name":"Namoluk Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/446/043/890446043.geojson
+++ b/data/890/446/043/890446043.geojson
@@ -22,11 +22,17 @@
     "name:ara_x_preferred":[
         "\u0625\u0639\u0635\u0627\u0631 \u0628\u0648\u0628\u0627"
     ],
+    "name:bcl_x_preferred":[
+        "Bagyong Bopha"
+    ],
     "name:cat_x_preferred":[
         "Tif\u00f3 Bopha"
     ],
     "name:cym_x_preferred":[
         "Teiff\u0175n Bopha"
+    ],
+    "name:deu_x_preferred":[
+        "Taifun Bopha"
     ],
     "name:eng_x_preferred":[
         "Typhoon Bopha"
@@ -55,8 +61,14 @@
     "name:spa_x_preferred":[
         "Tif\u00f3n Bopha"
     ],
+    "name:tgl_x_preferred":[
+        "Bagyong Pablo"
+    ],
     "name:tha_x_preferred":[
         "\u0e1e\u0e32\u0e22\u0e38\u0e44\u0e15\u0e49\u0e1d\u0e38\u0e48\u0e19\u0e42\u0e1a\u0e1e\u0e32"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0422\u0430\u0439\u0444\u0443\u043d \u0411\u043e\u0444\u0430"
     ],
     "name:und_x_variant":[
         "Lekinioch"
@@ -93,7 +105,7 @@
         }
     ],
     "wof:id":890446043,
-    "wof:lastmodified":1566596169,
+    "wof:lastmodified":1690893332,
     "wof:name":"Lukunor Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/446/047/890446047.geojson
+++ b/data/890/446/047/890446047.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ary_x_preferred":[
+        "\u0648\u064a\u0644\u0627\u064a\u0629 \u064a\u0627\u067e"
+    ],
     "name:ceb_x_preferred":[
         "State of Yap"
     ],
@@ -27,6 +30,9 @@
     ],
     "name:eng_x_preferred":[
         "Yap State"
+    ],
+    "name:eus_x_preferred":[
+        "Yap"
     ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0627\u0644\u062a \u06cc\u0627\u067e"
@@ -37,8 +43,20 @@
     "name:fra_x_preferred":[
         "Yap"
     ],
+    "name:frr_x_preferred":[
+        "Yap"
+    ],
     "name:hin_x_preferred":[
         "\u092f\u093e\u092a \u0930\u093e\u091c\u094d\u092f"
+    ],
+    "name:hrv_x_preferred":[
+        "Yap"
+    ],
+    "name:ind_x_preferred":[
+        "Negara Bagian Yap"
+    ],
+    "name:ita_x_preferred":[
+        "Yap"
     ],
     "name:jpn_x_preferred":[
         "\u30e4\u30c3\u30d7\u5dde"
@@ -49,6 +67,12 @@
     "name:kor_x_preferred":[
         "\uc57c\ud504\uc8fc"
     ],
+    "name:lav_x_preferred":[
+        "Japa"
+    ],
+    "name:nan_x_preferred":[
+        "Yap Chiu"
+    ],
     "name:oci_x_preferred":[
         "Iap"
     ],
@@ -57,6 +81,9 @@
     ],
     "name:rus_x_preferred":[
         "\u042f\u043f"
+    ],
+    "name:tur_x_preferred":[
+        "Yap"
     ],
     "name:ukr_x_preferred":[
         "\u042f\u043f"
@@ -93,7 +120,7 @@
         }
     ],
     "wof:id":890446047,
-    "wof:lastmodified":1566596169,
+    "wof:lastmodified":1690893331,
     "wof:name":"Ngulu Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/451/677/890451677.geojson
+++ b/data/890/451/677/890451677.geojson
@@ -33,6 +33,9 @@
     "name:fra_x_preferred":[
         "Dalipebinaw Municipality"
     ],
+    "name:fra_x_variant":[
+        "Dalipebinau"
+    ],
     "name:ita_x_preferred":[
         "Dalipebinaw"
     ],
@@ -44,6 +47,9 @@
     ],
     "name:pol_x_preferred":[
         "Dalipebinaw"
+    ],
+    "name:spa_x_preferred":[
+        "Dalipebinau"
     ],
     "qs:name":"Dalipebinaw Municipality",
     "qs:photos_9r":0,
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":890451677,
-    "wof:lastmodified":1627522134,
+    "wof:lastmodified":1690893344,
     "wof:name":"Dalipebinaw Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/679/890451679.geojson
+++ b/data/890/451/679/890451679.geojson
@@ -24,6 +24,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ceb_x_preferred":[
+        "Eauripik Atoll"
+    ],
     "name:deu_x_preferred":[
         "Eauripik"
     ],
@@ -45,6 +48,9 @@
     "name:jpn_x_preferred":[
         "\u30a8\u30a2\u30a6\u30ea\u30d4\u30af\u5cf6"
     ],
+    "name:lav_x_preferred":[
+        "\u0112uripika"
+    ],
     "name:lit_x_preferred":[
         "Eauripikas"
     ],
@@ -59,6 +65,9 @@
     ],
     "name:spa_x_preferred":[
         "Eauripik"
+    ],
+    "name:swe_x_preferred":[
+        "Eauripik Atoll"
     ],
     "name:wuu_x_preferred":[
         "\u6b50\u91cc\u76ae\u514b\u74b0\u7901"
@@ -105,7 +114,7 @@
         }
     ],
     "wof:id":890451679,
-    "wof:lastmodified":1566596181,
+    "wof:lastmodified":1690893343,
     "wof:name":"Eauripik Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/681/890451681.geojson
+++ b/data/890/451/681/890451681.geojson
@@ -45,6 +45,9 @@
     "name:jpn_x_preferred":[
         "\u30a8\u30e9\u30fc\u30c8\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Elato"
+    ],
     "name:mkd_x_preferred":[
         "\u0415\u043b\u0430\u0442\u043e"
     ],
@@ -59,6 +62,9 @@
     ],
     "name:swe_x_preferred":[
         "Elato Atoll"
+    ],
+    "name:tur_x_preferred":[
+        "Elato"
     ],
     "name:zho_x_preferred":[
         "\u57c3\u62c9\u6258\u74b0\u7901"
@@ -99,7 +105,7 @@
         }
     ],
     "wof:id":890451681,
-    "wof:lastmodified":1566596181,
+    "wof:lastmodified":1690893343,
     "wof:name":"Elato Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/683/890451683.geojson
+++ b/data/890/451/683/890451683.geojson
@@ -51,6 +51,9 @@
     "name:jpn_x_preferred":[
         "\u30d5\u30a1\u30a4\u30b9\u5cf6"
     ],
+    "name:lav_x_preferred":[
+        "Faisa"
+    ],
     "name:mkd_x_preferred":[
         "\u0424\u0430\u0438\u0441"
     ],
@@ -59,6 +62,9 @@
     ],
     "name:pol_x_preferred":[
         "Fais"
+    ],
+    "name:rus_x_preferred":[
+        "\u0424\u0430\u0438\u0441"
     ],
     "name:spa_x_preferred":[
         "Isla Fais"
@@ -112,7 +118,7 @@
         }
     ],
     "wof:id":890451683,
-    "wof:lastmodified":1566596182,
+    "wof:lastmodified":1690893344,
     "wof:name":"Fais Municipality",
     "wof:parent_id":85671227,
     "wof:placetype":"county",

--- a/data/890/451/699/890451699.geojson
+++ b/data/890/451/699/890451699.geojson
@@ -48,6 +48,9 @@
     "name:jpn_x_preferred":[
         "\u30e9\u30e2\u30c8\u30ec\u30c3\u30af\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Lamotreka"
+    ],
     "name:nld_x_preferred":[
         "Lamotrek"
     ],
@@ -58,6 +61,9 @@
         "Lamotrek"
     ],
     "name:swe_x_preferred":[
+        "Lamotrek"
+    ],
+    "name:tur_x_preferred":[
         "Lamotrek"
     ],
     "name:zho_x_preferred":[
@@ -99,7 +105,7 @@
         }
     ],
     "wof:id":890451699,
-    "wof:lastmodified":1566596182,
+    "wof:lastmodified":1690893344,
     "wof:name":"Lamotrek Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/701/890451701.geojson
+++ b/data/890/451/701/890451701.geojson
@@ -51,6 +51,9 @@
     "name:pol_x_preferred":[
         "Maap"
     ],
+    "name:por_x_preferred":[
+        "Maap"
+    ],
     "name:spa_x_preferred":[
         "Maap"
     ],
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890451701,
-    "wof:lastmodified":1566596181,
+    "wof:lastmodified":1690893343,
     "wof:name":"Maap Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/452/051/890452051.geojson
+++ b/data/890/452/051/890452051.geojson
@@ -40,6 +40,9 @@
     "name:jpn_x_preferred":[
         "\u30ce\u30e0\u30a6\u30a3\u30f3\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Nomvina"
+    ],
     "name:mkd_x_preferred":[
         "\u041d\u043e\u043c\u0432\u0438\u043d"
     ],
@@ -47,6 +50,9 @@
         "Nomwin"
     ],
     "name:pol_x_preferred":[
+        "Nomwin"
+    ],
+    "name:spa_x_preferred":[
         "Nomwin"
     ],
     "name:swe_x_preferred":[
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890452051,
-    "wof:lastmodified":1566596174,
+    "wof:lastmodified":1690893336,
     "wof:name":"Nomwin",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/453/053/890453053.geojson
+++ b/data/890/453/053/890453053.geojson
@@ -24,6 +24,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:cat_x_preferred":[
+        "Pulap"
+    ],
     "name:ceb_x_preferred":[
         "Pollap"
     ],
@@ -44,6 +47,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d7\u30f3\u30ca\u30c3\u30d7\u5cf6"
+    ],
+    "name:lav_x_preferred":[
+        "Pulapa"
     ],
     "name:mkd_x_preferred":[
         "\u041f\u0443\u043b\u0430\u043f"
@@ -96,7 +102,7 @@
         }
     ],
     "wof:id":890453053,
-    "wof:lastmodified":1566596176,
+    "wof:lastmodified":1690893339,
     "wof:name":"Pollap Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/453/055/890453055.geojson
+++ b/data/890/453/055/890453055.geojson
@@ -48,6 +48,9 @@
     "name:jpn_x_preferred":[
         "\u30d7\u30eb\u30ef\u30c3\u30c8\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Puluvata"
+    ],
     "name:lit_x_preferred":[
         "Poluvatas"
     ],
@@ -60,8 +63,14 @@
     "name:pol_x_preferred":[
         "Polowat"
     ],
+    "name:por_x_preferred":[
+        "Poluwat"
+    ],
     "name:swe_x_preferred":[
         "Polowat"
+    ],
+    "name:tur_x_preferred":[
+        "Poluwat"
     ],
     "name:und_x_variant":[
         "Puluwat Municipality"
@@ -105,7 +114,7 @@
         }
     ],
     "wof:id":890453055,
-    "wof:lastmodified":1566596176,
+    "wof:lastmodified":1690893339,
     "wof:name":"Polowat Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/454/163/890454163.geojson
+++ b/data/890/454/163/890454163.geojson
@@ -25,6 +25,9 @@
     "name:fas_x_preferred":[
         "\u0631\u0648\u0645\u0648\u0646\u06af"
     ],
+    "name:fra_x_preferred":[
+        "Rumung"
+    ],
     "name:ita_x_preferred":[
         "Rumung"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:nld_x_preferred":[
         "Rumung"
+    ],
+    "name:zho_x_preferred":[
+        "\u9b6f\u8499\u5cf6"
     ],
     "qs:name":"Rumung Island",
     "qs:photos_9r":0,
@@ -59,7 +65,7 @@
         }
     ],
     "wof:id":890454163,
-    "wof:lastmodified":1566596176,
+    "wof:lastmodified":1690893338,
     "wof:name":"Rumung Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/454/165/890454165.geojson
+++ b/data/890/454/165/890454165.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":-1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Ngulu"
+    ],
     "name:ceb_x_preferred":[
         "Ngulu Atoll"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30cc\u30b0\u30fc\u30eb\u74b0\u7901"
+    ],
+    "name:lav_x_preferred":[
+        "Nulu"
     ],
     "name:lit_x_preferred":[
         "Ngulu"
@@ -94,7 +100,7 @@
         }
     ],
     "wof:id":890454165,
-    "wof:lastmodified":1566596175,
+    "wof:lastmodified":1690893338,
     "wof:name":"Ngulu Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/454/173/890454173.geojson
+++ b/data/890/454/173/890454173.geojson
@@ -67,6 +67,9 @@
     "name:kor_x_preferred":[
         "\ub77c\ubaa8\ud2b8\ub809"
     ],
+    "name:lav_x_preferred":[
+        "Lamotreka"
+    ],
     "name:nld_x_preferred":[
         "Lamotrek"
     ],
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":890454173,
-    "wof:lastmodified":1636494976,
+    "wof:lastmodified":1690893338,
     "wof:name":"Lamotrek",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/454/379/890454379.geojson
+++ b/data/890/454/379/890454379.geojson
@@ -48,8 +48,17 @@
     "name:pol_x_preferred":[
         "Fanapanges"
     ],
+    "name:por_x_preferred":[
+        "Fala-Beguets"
+    ],
+    "name:spa_x_preferred":[
+        "Fanapanges"
+    ],
     "name:swe_x_preferred":[
         "Fanapanges Island"
+    ],
+    "name:zho_x_preferred":[
+        "\u6cd5\u62c9-\u8d1d\u76d6\u8328\u5c9b"
     ],
     "qs:name":"Fanapanges Municipality",
     "qs:photos_9r":0,
@@ -87,7 +96,7 @@
         }
     ],
     "wof:id":890454379,
-    "wof:lastmodified":1566596175,
+    "wof:lastmodified":1690893338,
     "wof:name":"Fanapanges Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/454/383/890454383.geojson
+++ b/data/890/454/383/890454383.geojson
@@ -39,6 +39,9 @@
     "name:jpn_x_preferred":[
         "\u30d7\u30eb\u30b5\u30c3\u30af\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Pulusuka"
+    ],
     "name:mkd_x_preferred":[
         "\u041f\u0443\u043b\u0443\u0441\u0443\u043a"
     ],
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":890454383,
-    "wof:lastmodified":1566596175,
+    "wof:lastmodified":1690893338,
     "wof:name":"Houk Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/231/890455231.geojson
+++ b/data/890/455/231/890455231.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":-1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Pulap"
+    ],
     "name:ceb_x_preferred":[
         "Pollap"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d7\u30f3\u30ca\u30c3\u30d7\u5cf6"
+    ],
+    "name:lav_x_preferred":[
+        "Pulapa"
     ],
     "name:mkd_x_preferred":[
         "\u041f\u0443\u043b\u0430\u043f"
@@ -81,7 +87,7 @@
         }
     ],
     "wof:id":890455231,
-    "wof:lastmodified":1566596174,
+    "wof:lastmodified":1690893337,
     "wof:name":"Pollap",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/455/451/890455451.geojson
+++ b/data/890/455/451/890455451.geojson
@@ -51,6 +51,9 @@
     "name:kor_x_preferred":[
         "\uc0ac\ud0c0\uc644 \ud658\ucd08"
     ],
+    "name:lav_x_preferred":[
+        "Satavana"
+    ],
     "name:lit_x_preferred":[
         "Satavanas"
     ],
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890455451,
-    "wof:lastmodified":1566596174,
+    "wof:lastmodified":1690893337,
     "wof:name":"Satowan Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/483/890455483.geojson
+++ b/data/890/455/483/890455483.geojson
@@ -48,6 +48,9 @@
     "name:jpn_x_preferred":[
         "\u30d5\u30a1\u30e9\u30a6\u30ec\u30c3\u30d7\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Faraulepa"
+    ],
     "name:nld_x_preferred":[
         "Faraulep"
     ],
@@ -58,6 +61,9 @@
         "Faraulep"
     ],
     "name:swe_x_preferred":[
+        "Faraulep"
+    ],
+    "name:tur_x_preferred":[
         "Faraulep"
     ],
     "name:und_x_variant":[
@@ -102,7 +108,7 @@
         }
     ],
     "wof:id":890455483,
-    "wof:lastmodified":1566596174,
+    "wof:lastmodified":1690893337,
     "wof:name":"Faraulep Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/485/890455485.geojson
+++ b/data/890/455/485/890455485.geojson
@@ -51,6 +51,9 @@
     "name:spa_x_preferred":[
         "Sebastian Anefal"
     ],
+    "name:sqi_x_preferred":[
+        "Sebastian Anefal"
+    ],
     "qs:name":"Gilman Municipality",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":890455485,
-    "wof:lastmodified":1566596174,
+    "wof:lastmodified":1690893336,
     "wof:name":"Gilman Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/487/890455487.geojson
+++ b/data/890/455/487/890455487.geojson
@@ -48,6 +48,9 @@
     "name:jpn_x_preferred":[
         "\u30a4\u30d5\u30a1\u30ea\u30af\u74b0\u7901"
     ],
+    "name:lav_x_preferred":[
+        "Ifalika"
+    ],
     "name:nld_x_preferred":[
         "Ifalik"
     ],
@@ -61,6 +64,9 @@
         "Ifaluk"
     ],
     "name:swe_x_preferred":[
+        "Ifalik"
+    ],
+    "name:tur_x_preferred":[
         "Ifalik"
     ],
     "name:wuu_x_preferred":[
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":890455487,
-    "wof:lastmodified":1566596174,
+    "wof:lastmodified":1690893337,
     "wof:name":"Ifalik Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.