### PR TITLE
fm concordances, placetype local, and more

### DIFF
--- a/data/856/324/31/85632431.geojson
+++ b/data/856/324/31/85632431.geojson
@@ -1050,6 +1050,7 @@
         "gp:id":23424815,
         "hasc:id":"FM",
         "ioc:id":"FSM",
+        "iso:code":"FM",
         "itu:id":"FSM",
         "loc:id":"n83074223",
         "m49:code":"583",
@@ -1062,6 +1063,7 @@
         "wd:id":"Q702",
         "wk:page":"Federated States of Micronesia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FM",
     "wof:country_alpha3":"FSM",
     "wof:geom_alt":[
@@ -1082,7 +1084,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639504,
+    "wof:lastmodified":1695881158,
     "wof:name":"Federated States of Micronesia",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/712/17/85671217.geojson
+++ b/data/856/712/17/85671217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032589,
-    "geom:area_square_m":400007919.99667,
+    "geom:area_square_m":400007522.378566,
     "geom:bbox":"154.238455,0.918158,158.338634,8.185085",
     "geom:latitude":6.896505,
     "geom:longitude":157.689161,
@@ -270,14 +270,16 @@
         "gn:id":2081550,
         "gp:id":2345341,
         "hasc:id":"FM.PO",
+        "iso:code":"FM-PNI",
         "iso:id":"FM-PNI",
         "qs_pg:id":235595,
         "unlc:id":"FM-PNI",
         "wd:id":"Q7771127",
         "wk:page":"Pohnpei State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FM",
-    "wof:geomhash":"f448725e12cd5857328d8d6f4caeacbc",
+    "wof:geomhash":"2f26ff18035fd2a169fd53fe02a3fa53",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -292,7 +294,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690893329,
+    "wof:lastmodified":1695884783,
     "wof:name":"Pohnpei",
     "wof:parent_id":85632431,
     "wof:placetype":"region",

--- a/data/856/712/21/85671221.geojson
+++ b/data/856/712/21/85671221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006113,
-    "geom:area_square_m":74972940.243345,
+    "geom:area_square_m":74973061.697925,
     "geom:bbox":"149.169037,5.286038,153.710704,8.987494",
     "geom:latitude":7.31241,
     "geom:longitude":151.536383,
@@ -321,14 +321,16 @@
         "gn:id":2082282,
         "gp:id":2345342,
         "hasc:id":"FM.CH",
+        "iso:code":"FM-TRK",
         "iso:id":"FM-TRK",
         "qs_pg:id":219553,
         "unlc:id":"FM-TRK",
         "wd:id":"Q221684",
         "wk:page":"Chuuk State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FM",
-    "wof:geomhash":"bcd3f90b399519d1574e573a4fdd5704",
+    "wof:geomhash":"3fd6cd6b955f27819f0f7ca5be335866",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690893329,
+    "wof:lastmodified":1695884783,
     "wof:name":"Chuuk",
     "wof:parent_id":85632431,
     "wof:placetype":"region",

--- a/data/856/712/27/85671227.geojson
+++ b/data/856/712/27/85671227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007942,
-    "geom:area_square_m":96858535.263234,
+    "geom:area_square_m":96857826.133448,
     "geom:bbox":"138.063813,7.344143,143.920339,9.77558",
     "geom:latitude":9.479668,
     "geom:longitude":138.29021,
@@ -244,14 +244,16 @@
         "gn:id":2081175,
         "gp:id":2345343,
         "hasc:id":"FM.YA",
+        "iso:code":"FM-YAP",
         "iso:id":"FM-YAP",
         "qs_pg:id":1285213,
         "unlc:id":"FM-YAP",
         "wd:id":"Q11342951",
         "wk:page":"Yap State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FM",
-    "wof:geomhash":"b9df456f67c4096f35859a747340eb09",
+    "wof:geomhash":"55b9887460d04bec05894f95599ab220",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -266,7 +268,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690893329,
+    "wof:lastmodified":1695884783,
     "wof:name":"Yap",
     "wof:parent_id":85632431,
     "wof:placetype":"region",

--- a/data/856/712/31/85671231.geojson
+++ b/data/856/712/31/85671231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009275,
-    "geom:area_square_m":114192433.692967,
+    "geom:area_square_m":114192516.36422,
     "geom:bbox":"162.91212,5.269761,163.04656,5.379706",
     "geom:latitude":5.318861,
     "geom:longitude":162.984539,
@@ -167,13 +167,15 @@
         "gn:id":2082036,
         "gp:id":2345340,
         "hasc:id":"FM.KO",
+        "iso:code":"FM-KSA",
         "iso:id":"FM-KSA",
         "qs_pg:id":894890,
         "unlc:id":"FM-KSA",
         "wd:id":"Q1785093"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FM",
-    "wof:geomhash":"4a4ed7b197742ced0215474f3f2eb05f",
+    "wof:geomhash":"30bc532af38437f2f1ded6df03106d7e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -188,7 +190,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690893329,
+    "wof:lastmodified":1695884784,
     "wof:name":"Kosrae",
     "wof:parent_id":85632431,
     "wof:placetype":"region",

--- a/data/890/417/413/890417413.geojson
+++ b/data/890/417/413/890417413.geojson
@@ -89,6 +89,7 @@
         "wd:id":"Q1964365",
         "wk:page":"Namoluk"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051201,
     "wof:geomhash":"aa6472bd704c8451bc2d123e3838ff99",
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":890417413,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Namoluk Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/417/415/890417415.geojson
+++ b/data/890/417/415/890417415.geojson
@@ -86,6 +86,7 @@
         "wd:id":"Q1107413",
         "wk:page":"Fayu Atoll"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051201,
     "wof:geomhash":"91b8b0de0f4c9f5410dbff1999abf79d",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890417415,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886617,
     "wof:name":"Nomwin Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/417/417/890417417.geojson
+++ b/data/890/417/417/890417417.geojson
@@ -86,6 +86,7 @@
         "wd:id":"Q3352704",
         "wk:page":"Oneop"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051201,
     "wof:geomhash":"c154a2005531eafc51080934ad94ecb1",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890417417,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Oneop Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/417/419/890417419.geojson
+++ b/data/890/417/419/890417419.geojson
@@ -108,9 +108,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626974,
+        "hasc:id_pseudo":"FM.XX.05",
         "qs_pg:id":694200,
         "wk:page":"Elafonisos"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469051201,
     "wof:geomhash":"9a4cb134530ca6a2b4224a5641ed0a38",
@@ -121,7 +123,7 @@
         }
     ],
     "wof:id":890417419,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695886738,
     "wof:name":"Onou",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/417/423/890417423.geojson
+++ b/data/890/417/423/890417423.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Piherarh"
@@ -44,8 +44,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626977,
+        "hasc:id_pseudo":"FM.XX.08",
         "qs_pg:id":694203
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469051201,
     "wof:geomhash":"5fded0d01c9859f17e111b29e3709421",
@@ -56,7 +58,7 @@
         }
     ],
     "wof:id":890417423,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887128,
     "wof:name":"Piherarh",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/417/425/890417425.geojson
+++ b/data/890/417/425/890417425.geojson
@@ -452,6 +452,7 @@
         "wd:id":"Q41493",
         "wk:page":"Ancient history"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051202,
     "wof:geomhash":"421d975cf4f72a7e1fa2a571f04f6221",
@@ -462,7 +463,7 @@
         }
     ],
     "wof:id":890417425,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Pwene Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/423/027/890423027.geojson
+++ b/data/890/423/027/890423027.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Weno-Choniro"
@@ -46,8 +46,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626992,
+        "hasc:id_pseudo":"FM.XX.15",
         "qs_pg:id":694217
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469051477,
     "wof:geomhash":"66c5fcb427288865ac6b71fc51575f20",
@@ -60,7 +62,7 @@
         }
     ],
     "wof:id":890423027,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887129,
     "wof:name":"Weno-Choniro",
     "wof:parent_id":85671221,
     "wof:placetype":"county",

--- a/data/890/423/029/890423029.geojson
+++ b/data/890/423/029/890423029.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Fonoton"
@@ -44,8 +44,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626993,
+        "hasc:id_pseudo":"FM.XX.01",
         "qs_pg:id":694218
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469051477,
     "wof:geomhash":"d582a4b6f66aaffe67ad9c5fbdd04d52",
@@ -56,7 +58,7 @@
         }
     ],
     "wof:id":890423029,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887128,
     "wof:name":"Fonoton",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/423/031/890423031.geojson
+++ b/data/890/423/031/890423031.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Paata-Tupunion"
@@ -44,8 +44,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626994,
+        "hasc:id_pseudo":"FM.XX.07",
         "qs_pg:id":694219
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469051477,
     "wof:geomhash":"5b5a790085a1d8714f3e5cb01d0f927b",
@@ -56,7 +58,7 @@
         }
     ],
     "wof:id":890423031,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887128,
     "wof:name":"Paata-Tupunion",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/343/890424343.geojson
+++ b/data/890/424/343/890424343.geojson
@@ -125,6 +125,7 @@
         "wd:id":"Q388347",
         "wk:page":"Kapingamarangi"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"4e132ba29aa25ae59b6e5f6be91b1bad",
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":890424343,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Kapingamarangi Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/345/890424345.geojson
+++ b/data/890/424/345/890424345.geojson
@@ -80,6 +80,7 @@
         "wd:id":"Q2516138",
         "wk:page":"Kitti (municipality)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"063c4e9715195d955c468c6a65712b69",
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":890424345,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Kitti Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/347/890424347.geojson
+++ b/data/890/424/347/890424347.geojson
@@ -256,6 +256,7 @@
         "wd:id":"Q514165",
         "wk:page":"Kolonia"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"980824fa3556f60a8a7de2578205bfd1",
@@ -268,7 +269,7 @@
         }
     ],
     "wof:id":890424347,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Kolonia Municipality",
     "wof:parent_id":85671217,
     "wof:placetype":"county",

--- a/data/890/424/349/890424349.geojson
+++ b/data/890/424/349/890424349.geojson
@@ -53,6 +53,7 @@
         "hasc:id":"FM.PO.MA",
         "qs_pg:id":694149
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"2ac534b87ca579a845493445b4d012cd",
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":890424349,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886617,
     "wof:name":"Madolenihm Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/353/890424353.geojson
+++ b/data/890/424/353/890424353.geojson
@@ -77,6 +77,7 @@
         "wd:id":"Q2288241",
         "wk:page":"Mokil"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"b76b64ed88f109d2b93b033a1bb612c2",
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":890424353,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886617,
     "wof:name":"Mokil Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/355/890424355.geojson
+++ b/data/890/424/355/890424355.geojson
@@ -91,6 +91,7 @@
         "wd:id":"Q2570130",
         "wk:page":"Nett"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"aba37707b78da735e4d3e7251bde0a72",
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":890424355,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Nett Municipality",
     "wof:parent_id":85671217,
     "wof:placetype":"county",

--- a/data/890/424/357/890424357.geojson
+++ b/data/890/424/357/890424357.geojson
@@ -85,6 +85,7 @@
         "wd:id":"Q7379073",
         "wk:page":"Rull"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"b5746c687f70925877a5963f717c7155",
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":890424357,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886617,
     "wof:name":"Rull Municipality",
     "wof:parent_id":85671227,
     "wof:placetype":"county",

--- a/data/890/424/359/890424359.geojson
+++ b/data/890/424/359/890424359.geojson
@@ -76,6 +76,7 @@
         "wd:id":"Q3942661",
         "wk:page":"Rumung"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"82bb9774b295f89b248992b57caecb70",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":890424359,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Rumung Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/361/890424361.geojson
+++ b/data/890/424/361/890424361.geojson
@@ -95,6 +95,7 @@
         "wd:id":"Q1569116",
         "wk:page":"Piagailoe"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"280307fba151d450bcb50adb09adb832",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":890424361,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Satawal Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/363/890424363.geojson
+++ b/data/890/424/363/890424363.geojson
@@ -77,6 +77,7 @@
         "wd:id":"Q678801",
         "wk:page":"Tomils"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051540,
     "wof:geomhash":"1d5ab5e19cb066c60c2011a90802bad4",
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":890424363,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Tomil Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/365/890424365.geojson
+++ b/data/890/424/365/890424365.geojson
@@ -119,6 +119,7 @@
         "wd:id":"Q1350219",
         "wk:page":"Ulithi"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051541,
     "wof:geomhash":"840a276411481567dcc948886205f3a8",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":890424365,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Ulithi Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/367/890424367.geojson
+++ b/data/890/424/367/890424367.geojson
@@ -58,6 +58,7 @@
         "wd:id":"Q7037740",
         "wk:page":"Nimpal Channel Marine Conservation Area"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051541,
     "wof:geomhash":"3f161fddebf2ccdace993adaadce63a8",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":890424367,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Weloy Municipality",
     "wof:parent_id":85671227,
     "wof:placetype":"county",

--- a/data/890/424/371/890424371.geojson
+++ b/data/890/424/371/890424371.geojson
@@ -125,6 +125,7 @@
         "wd:id":"Q567984",
         "wk:page":"Woleai"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051541,
     "wof:geomhash":"0f137e33bd7c0ada05833713c18b7410",
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":890424371,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Woleai Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/373/890424373.geojson
+++ b/data/890/424/373/890424373.geojson
@@ -80,6 +80,7 @@
         "wd:id":"Q6912104",
         "wk:page":"Mori Koben"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051541,
     "wof:geomhash":"9a221586b992d2f727aac552d8bacebc",
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":890424373,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Eot Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/375/890424375.geojson
+++ b/data/890/424/375/890424375.geojson
@@ -142,6 +142,7 @@
         "qs_pg:id":694185,
         "wk:page":"Ettal"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051541,
     "wof:geomhash":"cec57f3f0500d72d1818905da089229b",
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":890424375,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Ettal Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/424/377/890424377.geojson
+++ b/data/890/424/377/890424377.geojson
@@ -86,6 +86,7 @@
         "wd:id":"Q1604754",
         "wk:page":"Fananu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051541,
     "wof:geomhash":"221a62f602fe1a8349bf51b3d7e0cbac",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890424377,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Fananu Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/689/890429689.geojson
+++ b/data/890/429/689/890429689.geojson
@@ -101,6 +101,7 @@
         "wd:id":"Q1115131",
         "wk:page":"Ngulu Atoll"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051825,
     "wof:geomhash":"ef5e6e59de0f06b8d48cdb77bbc64df0",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890429689,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Ngulu Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/691/890429691.geojson
+++ b/data/890/429/691/890429691.geojson
@@ -107,6 +107,7 @@
         "wd:id":"Q1191287",
         "wk:page":"Satawan"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051825,
     "wof:geomhash":"e3a25bd1da30d1b1815c7e5e9df3371e",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890429691,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Kuttu Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/693/890429693.geojson
+++ b/data/890/429/693/890429693.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Lekinioch"
@@ -47,8 +47,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626966,
+        "hasc:id_pseudo":"FM.XX.03",
         "qs_pg:id":694192
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469051825,
     "wof:geomhash":"521062b2207fb07d0efed385e4521725",
@@ -59,7 +61,7 @@
         }
     ],
     "wof:id":890429693,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887128,
     "wof:name":"Lekinioch",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/429/695/890429695.geojson
+++ b/data/890/429/695/890429695.geojson
@@ -106,6 +106,7 @@
         "wd:id":"Q1573799",
         "wk:page":"Namonuito Atoll"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469051825,
     "wof:geomhash":"89dbbb2a4b5556e0036a3e14df886b16",
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":890429695,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Makur Municipality",
     "wof:parent_id":85671221,
     "wof:placetype":"county",

--- a/data/890/435/639/890435639.geojson
+++ b/data/890/435/639/890435639.geojson
@@ -101,6 +101,7 @@
         "wd:id":"Q1313806",
         "wk:page":"Sapwuahfik"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052075,
     "wof:geomhash":"37c8bdcbbed001376a969af2c72f2652",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890435639,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886739,
     "wof:name":"Ngatik Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/435/643/890435643.geojson
+++ b/data/890/435/643/890435643.geojson
@@ -131,6 +131,7 @@
         "wd:id":"Q187864",
         "wk:page":"Nukuoro"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052075,
     "wof:geomhash":"81e6b6dc8e8f9562866d22c4f7629b65",
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":890435643,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886739,
     "wof:name":"Nukuoro Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/436/353/890436353.geojson
+++ b/data/890/436/353/890436353.geojson
@@ -83,6 +83,7 @@
         "wd:id":"Q3757207",
         "wk:page":"Gagil"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052108,
     "wof:geomhash":"f6c22aef036b86fbcdebf10609ba9e75",
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":890436353,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Gagil Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/436/355/890436355.geojson
+++ b/data/890/436/355/890436355.geojson
@@ -76,6 +76,7 @@
         "wd:id":"Q3812782",
         "wk:page":"Kanifay"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052108,
     "wof:geomhash":"8259953229102b7e10d5fd7fafeb87e8",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":890436355,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Kanifay Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/436/547/890436547.geojson
+++ b/data/890/436/547/890436547.geojson
@@ -103,6 +103,7 @@
         "qs_pg:id":694196,
         "wk:page":"Kl\u00ed\u017eska Nem\u00e1"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052115,
     "wof:geomhash":"bdaa28d4121da81cbb500c1961157568",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":890436547,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Nema Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/571/890442571.geojson
+++ b/data/890/442/571/890442571.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:ceb_x_preferred":[
         "Namonuito Atoll"
@@ -87,10 +87,12 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626975,
+        "hasc:id_pseudo":"FM.XX.06",
         "qs_pg:id":694201,
         "wd:id":"Q1573799",
         "wk:page":"Namonuito Atoll"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469052368,
     "wof:geomhash":"012e311596a89f02e9a27c8e1c61e3fe",
@@ -101,7 +103,7 @@
         }
     ],
     "wof:id":890442571,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886953,
     "wof:name":"Onoun Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/573/890442573.geojson
+++ b/data/890/442/573/890442573.geojson
@@ -234,6 +234,7 @@
         "wd:id":"Q221684",
         "wk:page":"Chuuk State"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052368,
     "wof:geomhash":"19df71b152df2387bbad2df05cd27a15",
@@ -244,7 +245,7 @@
         }
     ],
     "wof:id":890442573,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Parem Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/749/890442749.geojson
+++ b/data/890/442/749/890442749.geojson
@@ -107,6 +107,7 @@
         "wd:id":"Q1191287",
         "wk:page":"Satawan"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052376,
     "wof:geomhash":"d6295c0bb9aad112500137d72db5e5e8",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890442749,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Moch Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/769/890445769.geojson
+++ b/data/890/445/769/890445769.geojson
@@ -55,6 +55,7 @@
         "qs_pg:id":694209,
         "wk:page":"Line 02 (Phnom Penh Bus Rapid Transit)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052522,
     "wof:geomhash":"b2e9def54da2a21f6a7d56e6be2040d4",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":890445769,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Ta Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/773/890445773.geojson
+++ b/data/890/445/773/890445773.geojson
@@ -86,6 +86,7 @@
         "wd:id":"Q1604777",
         "wk:page":"Tamatam"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052522,
     "wof:geomhash":"915fcc47ea2af3dd543b5f04e0c3fbcd",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890445773,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Tamatam Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/775/890445775.geojson
+++ b/data/890/445/775/890445775.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Tolensom"
@@ -44,8 +44,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626986,
+        "hasc:id_pseudo":"FM.XX.12",
         "qs_pg:id":694211
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469052522,
     "wof:geomhash":"4eabedf2e02ccc7a95d4c0e7482ad88c",
@@ -56,7 +58,7 @@
         }
     ],
     "wof:id":890445775,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887129,
     "wof:name":"Tolensom",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/777/890445777.geojson
+++ b/data/890/445/777/890445777.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:ara_x_preferred":[
         "\u062a\u0634\u0648\u0643 \u0644\u0627\u063a\u0648\u0646"
@@ -129,10 +129,12 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626987,
+        "hasc:id_pseudo":"FM.XX.13",
         "qs_pg:id":694212,
         "wd:id":"Q3593555",
         "wk:page":"Chuuk Lagoon"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469052522,
     "wof:geomhash":"2231d9f872f4ff445a8e4c3f09dbe070",
@@ -143,7 +145,7 @@
         }
     ],
     "wof:id":890445777,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886953,
     "wof:name":"Tonoas Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/779/890445779.geojson
+++ b/data/890/445/779/890445779.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Siis"
@@ -42,9 +42,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626988,
+        "hasc:id_pseudo":"FM.XX.11",
         "qs_pg:id":694213,
         "wk:page":"List of FIPS region codes (S\u2013U)"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469052522,
     "wof:geomhash":"bf4fe508c59b79fcdfe05844a47d8ff1",
@@ -55,7 +57,7 @@
         }
     ],
     "wof:id":890445779,
-    "wof:lastmodified":1694497770,
+    "wof:lastmodified":1695887129,
     "wof:name":"Siis Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/781/890445781.geojson
+++ b/data/890/445/781/890445781.geojson
@@ -53,6 +53,7 @@
         "hasc:id":"FM.CH.UD",
         "qs_pg:id":694214
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052522,
     "wof:geomhash":"fbcc6ee039874772fced086048d25091",
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":890445781,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Udot-Fonuweisom Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/783/890445783.geojson
+++ b/data/890/445/783/890445783.geojson
@@ -53,6 +53,7 @@
         "hasc:id":"FM.CH.UM",
         "qs_pg:id":694215
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052522,
     "wof:geomhash":"2a05fa920781e45d6e9e8ebb84ca6b24",
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":890445783,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Uman-Fonuweisom Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/445/785/890445785.geojson
+++ b/data/890/445/785/890445785.geojson
@@ -141,9 +141,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626991,
+        "hasc:id_pseudo":"FM.XX.14",
         "qs_pg:id":694216,
         "wk:page":"Chuuk State"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469052522,
     "wof:geomhash":"2da32e293485591dce81b72ad5199960",
@@ -154,7 +156,7 @@
         }
     ],
     "wof:id":890445785,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695886738,
     "wof:name":"Unanu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/677/890451677.geojson
+++ b/data/890/451/677/890451677.geojson
@@ -79,6 +79,7 @@
         "wd:id":"Q3397624",
         "wk:page":"Dalipebinau"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052790,
     "wof:geomhash":"aaf3bfb34c05544d221d750a83e249f0",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":890451677,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886616,
     "wof:name":"Dalipebinaw Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/679/890451679.geojson
+++ b/data/890/451/679/890451679.geojson
@@ -104,6 +104,7 @@
         "wd:id":"Q1278448",
         "wk:page":"Eauripik"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052790,
     "wof:geomhash":"5b48da65a40991e9f6247b2e2f8786ee",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890451679,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886739,
     "wof:name":"Eauripik Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/681/890451681.geojson
+++ b/data/890/451/681/890451681.geojson
@@ -95,6 +95,7 @@
         "wd:id":"Q1325019",
         "wk:page":"Elato"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052790,
     "wof:geomhash":"a17e3ff83e27b4d62dc8bb5b287caf9f",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":890451681,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886739,
     "wof:name":"Elato Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/683/890451683.geojson
+++ b/data/890/451/683/890451683.geojson
@@ -106,6 +106,7 @@
         "wd:id":"Q1393489",
         "wk:page":"Fais Island"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052790,
     "wof:geomhash":"829a0fbfde83174cdad6ebbfd5247bd2",
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":890451683,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886739,
     "wof:name":"Fais Municipality",
     "wof:parent_id":85671227,
     "wof:placetype":"county",

--- a/data/890/451/699/890451699.geojson
+++ b/data/890/451/699/890451699.geojson
@@ -95,6 +95,7 @@
         "wd:id":"Q1779228",
         "wk:page":"Lamotrek"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052790,
     "wof:geomhash":"fa4720e256f41fc3945f3f77ec2e56d9",
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":890451699,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886739,
     "wof:name":"Lamotrek Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/451/701/890451701.geojson
+++ b/data/890/451/701/890451701.geojson
@@ -86,6 +86,7 @@
         "wd:id":"Q1133174",
         "wk:page":"Maap"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052790,
     "wof:geomhash":"4408ec90e907ecd0fae4953e31d61f61",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890451701,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886739,
     "wof:name":"Maap Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/453/051/890453051.geojson
+++ b/data/890/453/051/890453051.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Piis-Emwar"
@@ -44,8 +44,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626978,
+        "hasc:id_pseudo":"FM.XX.09",
         "qs_pg:id":694204
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469052839,
     "wof:geomhash":"6c263783ecb1db6119318a2197f5fb4b",
@@ -56,7 +58,7 @@
         }
     ],
     "wof:id":890453051,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887128,
     "wof:name":"Piis-Emwar",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/453/053/890453053.geojson
+++ b/data/890/453/053/890453053.geojson
@@ -92,6 +92,7 @@
         "wd:id":"Q1115044",
         "wk:page":"Pulap"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052839,
     "wof:geomhash":"c651c7bdcbab4a6499f318e626cccf13",
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":890453053,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Pollap Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/453/055/890453055.geojson
+++ b/data/890/453/055/890453055.geojson
@@ -104,6 +104,7 @@
         "wd:id":"Q2064464",
         "wk:page":"Poluwat"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052839,
     "wof:geomhash":"80603c7bbdc6ce4f0399a533fe538cdf",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890453055,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Polowat Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/453/057/890453057.geojson
+++ b/data/890/453/057/890453057.geojson
@@ -53,6 +53,7 @@
         "hasc:id":"FM.CH.RO",
         "qs_pg:id":694207
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052839,
     "wof:geomhash":"a0d1d8b9d2bab3ae6a6183713aaa9c0e",
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":890453057,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Ramanum Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/453/059/890453059.geojson
+++ b/data/890/453/059/890453059.geojson
@@ -64,6 +64,7 @@
         "qs_pg:id":694208,
         "wk:page":"Ruo"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052839,
     "wof:geomhash":"38304e32e003b5c00fee6c0bf7ded999",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":890453059,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Ruo Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/453/063/890453063.geojson
+++ b/data/890/453/063/890453063.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Piis-Panewu"
@@ -44,8 +44,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626995,
+        "hasc:id_pseudo":"FM.XX.10",
         "qs_pg:id":694220
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469052839,
     "wof:geomhash":"222f52b78f0281e297ba2740a8a56a02",
@@ -56,7 +58,7 @@
         }
     ],
     "wof:id":890453063,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887128,
     "wof:name":"Piis-Panewu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/453/065/890453065.geojson
+++ b/data/890/453/065/890453065.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
         "Oneisom"
@@ -44,8 +44,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626996,
+        "hasc:id_pseudo":"FM.XX.04",
         "qs_pg:id":694221
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469052839,
     "wof:geomhash":"025f08469a3ca9b1a2886050c7602859",
@@ -56,7 +58,7 @@
         }
     ],
     "wof:id":890453065,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887128,
     "wof:name":"Oneisom",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/454/379/890454379.geojson
+++ b/data/890/454/379/890454379.geojson
@@ -86,6 +86,7 @@
         "wd:id":"Q3066319",
         "wk:page":"Fala-Beguets"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052897,
     "wof:geomhash":"3dd491503dcc3a2ce3cc7b6dbd3b9219",
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890454379,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Fanapanges Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/454/381/890454381.geojson
+++ b/data/890/454/381/890454381.geojson
@@ -53,6 +53,7 @@
         "hasc:id":"FM.CH.FF",
         "qs_pg:id":694188
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052897,
     "wof:geomhash":"b9b778c834b532d36b98b00d4d288a84",
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":890454381,
-    "wof:lastmodified":1694492673,
+    "wof:lastmodified":1695886618,
     "wof:name":"Fefen Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/454/383/890454383.geojson
+++ b/data/890/454/383/890454383.geojson
@@ -22,7 +22,7 @@
     "lbl:max_zoom":10.0,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:ceb_x_preferred":[
         "Houk Island"
@@ -75,10 +75,12 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7626963,
+        "hasc:id_pseudo":"FM.XX.02",
         "qs_pg:id":694189,
         "wd:id":"Q1444721",
         "wk:page":"Pulusuk"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"FM",
     "wof:created":1469052897,
     "wof:geomhash":"137c98cb343046de33ac856def5b69a9",
@@ -89,7 +91,7 @@
         }
     ],
     "wof:id":890454383,
-    "wof:lastmodified":1694497769,
+    "wof:lastmodified":1695886953,
     "wof:name":"Houk Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/451/890455451.geojson
+++ b/data/890/455/451/890455451.geojson
@@ -104,6 +104,7 @@
         "wd:id":"Q1191287",
         "wk:page":"Satawan"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052953,
     "wof:geomhash":"d2cd4ecf0354f687d3476203a3234165",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890455451,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Satowan Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/483/890455483.geojson
+++ b/data/890/455/483/890455483.geojson
@@ -98,6 +98,7 @@
         "wd:id":"Q1396235",
         "wk:page":"Faraulep"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052954,
     "wof:geomhash":"bcb1e5f9442a3f04deddc6d1bc67fd08",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":890455483,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886737,
     "wof:name":"Faraulep Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/485/890455485.geojson
+++ b/data/890/455/485/890455485.geojson
@@ -80,6 +80,7 @@
         "wd:id":"Q3476865",
         "wk:page":"Sebastian Anefal"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052954,
     "wof:geomhash":"93a65c3ec793ebbc6463a8107b6525e8",
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":890455485,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Gilman Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/487/890455487.geojson
+++ b/data/890/455/487/890455487.geojson
@@ -104,6 +104,7 @@
         "wd:id":"Q1430734",
         "wk:page":"Ifalik"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"FM",
     "wof:created":1469052954,
     "wof:geomhash":"ef6adea82e2530fe08fb3129b5e579fb",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":890455487,
-    "wof:lastmodified":1694492373,
+    "wof:lastmodified":1695886738,
     "wof:name":"Ifalik Municipality",
     "wof:parent_id":-1,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.